### PR TITLE
Add Apple Silicon compatibility

### DIFF
--- a/scdiffeq/core/_scdiffeq.py
+++ b/scdiffeq/core/_scdiffeq.py
@@ -445,7 +445,7 @@ class scDiffEq(utils.ABCParse):
         accelerator=None,
         log_every_n_steps=1,
         reload_dataloaders_every_n_epochs=1,
-        devices=None,
+        devices=1,
         deterministic=False,
         **kwargs,
     ):

--- a/scdiffeq/core/callbacks/_visualize_tracked_loss.py
+++ b/scdiffeq/core/callbacks/_visualize_tracked_loss.py
@@ -204,7 +204,7 @@ class LossTrackingVisualization(utils.ABCParse):
             nplots += len(self._PLOT_INPUTS["train"].keys())
         if self._HAS_PRETRAIN:
             nplots += len(self._PLOT_INPUTS["pretrain"].keys())
-
+        print(f"nplots: {nplots}")
         return nplots
 
     def __layout__(self):
@@ -262,6 +262,10 @@ class VisualizeTrackedLoss(lightning.Callback):
         self._INFO = utils.InfoMessage()
         self.fname = fname
         self.viz_frequency = viz_frequency
+        
+    @property
+    def _VIZ_DISABLE(self):
+        return not (self.vis_frequency is None)
         
     @property
     def save_path(self):

--- a/scdiffeq/core/configs/_lightning_trainer_configuration.py
+++ b/scdiffeq/core/configs/_lightning_trainer_configuration.py
@@ -75,15 +75,12 @@ class LightningTrainerConfiguration(utils.ABCParse):
     
     @property
     def accelerator(self):
-        if not isinstance(self._accelerator, NoneType):
+        if not self._accelerator is None:
             return self._accelerator
         if torch.cuda.is_available():
             return "gpu"
-        # would love to include mps however, currently (torch v1.13)
-        # does not have enough compatability with libraries we depend
-        # on to be used with Apple Silicon.
-        # if torch.backends.mps.is_available():
-        #     return "mps"
+        if torch.backends.mps.is_available(): # experimental
+            return "mps"
         return "cpu"
 
     # -- trainers: -------------------------------------------------------------
@@ -131,7 +128,7 @@ class LightningTrainerConfiguration(utils.ABCParse):
         max_epochs=500,
         monitor=None,
         accelerator=None,
-        devices=None,
+        devices=1,
         prefix: str = "",
         log_every_n_steps=1,
         flush_logs_every_n_steps: int = 1,

--- a/scdiffeq/core/utils/_scdiffeq_logger.py
+++ b/scdiffeq/core/utils/_scdiffeq_logger.py
@@ -44,9 +44,9 @@ class scDiffEqLogger(AutoParseBase):
 
     @property
     def VERSIONED_MODEL_OUTDIR(self):
-        
-        if self._PASSED_CKPT_MATCHES_MODEL_PARENT_DIR:
-            return self.VERSION_FROM_CKPT
+        if not self._ckpt_path is None:
+            if self._PASSED_CKPT_MATCHES_MODEL_PARENT_DIR:
+                return self.VERSION_FROM_CKPT
         
         return os.path.join(
             self.PARENT_MODEL_OUTDIR,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 
 setuptools.setup(
     name="scdiffeq",
-    version="0.0.47rc1",
+    version="0.0.48rc0",
     python_requires=">3.9.0",
     author="Michael E. Vinyard - Harvard University - Massachussetts General Hospital - Broad Institute of MIT and Harvard",
     author_email="mvinyard@broadinstitute.org",
@@ -33,6 +33,8 @@ setuptools.setup(
         "annoyance==0.0.18",
         "ABCParse==0.0.3",
         "scdiffeq-plots==0.0.1rc2",
+        "plotly==5.15.0",
+        "scvelo==0.2.5",
     ],
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
* Automatically detects / uses Apple Silicon GPU, if found. Was previously precluded because of the incompatibilities in the functions used by `torch` under the hood of `torchsde`. These appear to be resolved, now. Still experimental. Only tested on an M1 machine, thus far.