### PR TITLE
Add a callback to monitor memory usage

### DIFF
--- a/scdiffeq/_backend_utilities/__init__.py
+++ b/scdiffeq/_backend_utilities/__init__.py
@@ -1,2 +1,3 @@
 
 from ._anndata_index_lookup import ObsIndexLookUp, VarIndexLookUp
+from ._log_memory_usage import log_memory_usage

--- a/scdiffeq/_backend_utilities/__init__.py
+++ b/scdiffeq/_backend_utilities/__init__.py
@@ -1,3 +1,2 @@
 
 from ._anndata_index_lookup import ObsIndexLookUp, VarIndexLookUp
-from ._log_memory_usage import log_memory_usage

--- a/scdiffeq/_backend_utilities/_log_memory_usage.py
+++ b/scdiffeq/_backend_utilities/_log_memory_usage.py
@@ -1,6 +1,0 @@
-import psutil, os
-
-def log_memory_usage(epoch):
-    process = psutil.Process(os.getpid())
-    mem = process.memory_info().rss / 1024 ** 2  # in MB
-    print(f"Epoch {epoch} - Memory Usage: {mem:.2f} MB")

--- a/scdiffeq/_backend_utilities/_log_memory_usage.py
+++ b/scdiffeq/_backend_utilities/_log_memory_usage.py
@@ -1,0 +1,6 @@
+import psutil, os
+
+def log_memory_usage(epoch):
+    process = psutil.Process(os.getpid())
+    mem = process.memory_info().rss / 1024 ** 2  # in MB
+    print(f"Epoch {epoch} - Memory Usage: {mem:.2f} MB")

--- a/scdiffeq/core/_mix_ins/_model_config_mix_in.py
+++ b/scdiffeq/core/_mix_ins/_model_config_mix_in.py
@@ -14,7 +14,7 @@ class ModelConfigMixIn(object):
         """ """
                 
         self.TrainerGenerator = configs.LightningTrainerConfiguration(
-            save_dir=self._name
+            save_dir=self._name,
         )
 
     def configure_model(

--- a/scdiffeq/core/_mix_ins/_training_routine_mix_ins.py
+++ b/scdiffeq/core/_mix_ins/_training_routine_mix_ins.py
@@ -80,6 +80,7 @@ class PreTrainMixIn(BaseRoutineMixIn):
             pretrain_version=self._PRETRAIN_CONFIG_COUNT,
             train_version=self._TRAIN_CONFIG_COUNT,
             callbacks=self._pretrain_callbacks,
+            monitor_hardware=self._monitor_hardware,
             **self._TRAINER_KWARGS,
         )
 

--- a/scdiffeq/core/_scdiffeq.py
+++ b/scdiffeq/core/_scdiffeq.py
@@ -313,6 +313,7 @@ class scDiffEq(
         decoder_bias: bool = True,
         decoder_output_bias: bool = True,
         ckpt_path: Optional[Union[pathlib.Path, str]] = None,
+        monitor_hardware: bool = False,
         version: str = __version__,
         *args,
         **kwargs,

--- a/scdiffeq/core/callbacks/__init__.py
+++ b/scdiffeq/core/callbacks/__init__.py
@@ -8,3 +8,4 @@ from ._testing import Testing
 # from ._visualize_tracked_loss import ModelTracker, VisualizeTrackedLoss
 # from ._visualize_predictions import VisualizePredictions
 from ._model_logging import ModelLogging
+from ._memory_monitor import MemoryMonitor

--- a/scdiffeq/core/callbacks/_memory_monitor.py
+++ b/scdiffeq/core/callbacks/_memory_monitor.py
@@ -1,0 +1,40 @@
+# -- import packages: ----------------------------------------------------------
+import lightning
+import os
+import psutil
+import torch
+import wandb
+
+
+# -- operational cls: ----------------------------------------------------------
+class MemoryMonitor(lightning.pytorch.callbacks.Callback):
+    
+    def __init__(self, log_gpu=True):
+        
+        super().__init__()
+        
+        self.log_gpu = log_gpu
+        self.process = psutil.Process(os.getpid())
+        
+    def _log_cpu_ram(self, trainer):
+        mem = self.process.memory_info().rss / 1024 ** 2  # in MB
+        print(f"[MemoryLogger] Epoch {trainer.current_epoch}: CPU RAM: {mem:.2f} MB")
+        wandb.log({"Memory/CPU_RAM_MB": mem})
+        
+    def _log_gpu_ram(self, trainer, lit_module):
+        if self.log_gpu and lit_module.device.type == 'cuda':
+            gpu_mem_allocated = lit_module.device
+            mem_allocated = torch.cuda.memory_allocated(lit_module.device) / 1024 ** 2
+            mem_reserved = torch.cuda.memory_reserved(lit_module.device) / 1024 ** 2
+            print(f"[MemoryLogger] Epoch {trainer.current_epoch}: GPU Allocated: {mem_allocated:.2f} MB | Reserved: {mem_reserved:.2f} MB")
+            wandb.log(
+                {
+                    "Memory/GPU_Allocated_MB": mem_allocated,
+                    "Memory/GPU_Reserved_MB": mem_reserved,
+                }
+            )
+
+    def on_train_epoch_end(self, trainer, lit_module):
+
+        self._log_cpu_ram(trainer=trainer)
+        self._log_gpu_ram(trainer=trainer, lit_module=lit_module)

--- a/scdiffeq/core/configs/_lightning_callbacks_configuration.py
+++ b/scdiffeq/core/configs/_lightning_callbacks_configuration.py
@@ -1,27 +1,16 @@
 
-__module_name__ = "_lightning_callbacks_configuration.py"
-__doc__ = """where built-in callbacks are configured"""
-__author__ = ", ".join(["Michael E. Vinyard"])
-__email__ = ", ".join(["mvinyard.ai@gmail.com"])
-
-
 # -- import packages: ---------------------------------------------------------
 
-import os
 import ABCParse
-from lightning import Callback
-from lightning.pytorch.callbacks import (
-    ModelCheckpoint, StochasticWeightAveraging
-)
-
-
+import lightning
+import os
 
 # -- import local dependencies: -----------------------------------------------
 from .. import utils, callbacks
 
 
 # -- supporting class: --------------------------------------------------------
-class InterTrainerEpochCounter(Callback):
+class InterTrainerEpochCounter(lightning.pytorch.callbacks.Callback):
     def __init__(self):
         ...
 #         self.COMPLETED_EPOCHS = 0
@@ -43,19 +32,19 @@ class LightningCallbacksConfiguration(ABCParse.ABCParse):
     def BuiltInCallbacks(self):
 
         return [
-        ModelCheckpoint(
-            every_n_epochs=self._every_n_epochs,
-            save_on_train_epoch_end=True,
-            save_top_k=self._save_top_k,
-            save_last=self._save_last,
-            monitor=self._monitor,
-        ),
+            lightning.pytorch.callbacks.ModelCheckpoint(
+                every_n_epochs=self._every_n_epochs,
+                save_on_train_epoch_end=True,
+                save_top_k=self._save_top_k,
+                save_last=self._save_last,
+                monitor=self._monitor,
+            ),
             InterTrainerEpochCounter(),
             callbacks.ModelLogging(),
 #             callbacks.VisualizeTrackedLoss(
 #                 **utils.extract_func_kwargs(func = callbacks.VisualizeTrackedLoss, kwargs = self._PARAMS),
 #             ),
-            # StochasticWeightAveraging(swa_lrs=self.swa_lrs),
+            # lightning.pytorch.callbacks.StochasticWeightAveraging(swa_lrs=self.swa_lrs),
             # considering rm SWA pending better understanding
         ]
     
@@ -63,19 +52,20 @@ class LightningCallbacksConfiguration(ABCParse.ABCParse):
     def BuiltInPreTrainCallbacks(self):
 
         return [
-        ModelCheckpoint(
-            every_n_epochs=self._every_n_epochs,
-            save_on_train_epoch_end=True,
-            save_top_k=self._save_top_k,
-            save_last=self._save_last,
-            monitor=self._monitor,
-        ),
+            ModelCheckpoint(
+                every_n_epochs=self._every_n_epochs,
+                save_on_train_epoch_end=True,
+                save_top_k=self._save_top_k,
+                save_last=self._save_last,
+                monitor=self._monitor,
+            ),
             InterTrainerEpochCounter(),
+            
 #             callbacks.ModelLogging(),
 #             callbacks.VisualizeTrackedLoss(
 #                 **utils.extract_func_kwargs(func = callbacks.VisualizeTrackedLoss, kwargs = self._PARAMS),
 #             ),
-            # StochasticWeightAveraging(swa_lrs=self.swa_lrs),
+            # lightning.pytorch.callbacks.StochasticWeightAveraging(swa_lrs=self.swa_lrs),
             # considering rm SWA pending better understanding
         ]
 

--- a/scdiffeq/core/configs/_lightning_trainer_configuration.py
+++ b/scdiffeq/core/configs/_lightning_trainer_configuration.py
@@ -50,6 +50,7 @@ class LightningTrainerConfiguration(ABCParse.ABCParse):
         
         return callback_config(
             version = self._version,
+            monitor_hardware=self._monitor_hardware,
             stage = self._stage,
             viz_frequency = self._viz_frequency,
             model_name=self._model_name,
@@ -125,6 +126,7 @@ class LightningTrainerConfiguration(ABCParse.ABCParse):
         lr: float = None,
         model_name="scDiffEq_model",
         gradient_clip_val: float = 0.5,
+        monitor_hardware: bool = False,
         working_dir=os.getcwd(),
         train_version=0,
         pretrain_version=0,


### PR DESCRIPTION
- Adds: `scdiffeq.core.callbacks.MemoryMonitor` as a callback.
- Can be used by passing the `monitor_hardware (bool)` flag to `sdq.scDiffEq` as: `sdq.scDiffEq(..., monitor_hardware: bool)`. Default value: `False`.