### PR TITLE
Preprocess LARRY independently of downloading; seed the PCA

### DIFF
--- a/src/scdiffeq/datasets/_figshare_downloader.py
+++ b/src/scdiffeq/datasets/_figshare_downloader.py
@@ -55,9 +55,10 @@ class FigshareDownloadError(Exception):
 
 # -- payload validation: ------------------------------------------------------
 # Leading bytes that identify a well-formed payload, keyed by target suffix.
-# A WAF challenge page or a truncated transfer fails these, which is what keeps a
-# corrupt file from being written to the cache and only exploding much later
-# inside `anndata.read_h5ad`.
+# WAF challenge page or a truncated transfer fails these: keeps a corrupt file
+# from being written to the cache and only problematic later, inside
+# `anndata.read_h5ad`.
+
 _MAGIC_BY_SUFFIX = {
     ".h5ad": (b"\x89HDF\r\n\x1a\n",),
     ".h5": (b"\x89HDF\r\n\x1a\n",),
@@ -75,8 +76,8 @@ def _validate_payload(path: pathlib.Path, suffix: str) -> Tuple[bool, str]:
 
     Args:
         path: Location of the freshly downloaded (temporary) file.
-        suffix: Suffix of the *final* destination, e.g. ``".h5ad"``. The temp file
-            carries a ``.part`` suffix, so it cannot be used for this.
+        suffix: Suffix of the *final* destination, e.g. ``".h5ad"``. The temp
+        file carries a ``.part`` suffix, so it cannot be used for this.
 
     Returns:
         ``(is_valid, reason)``.
@@ -124,17 +125,17 @@ def _unlink(path: pathlib.Path) -> None:
 
 # -- operational class: -------------------------------------------------------
 class FigshareDownloader:
-    """Download dataset files, preferring sources that work without authentication.
+    """Download dataset files, preferring sources that work without auth.
 
     Sources are attempted in this order:
 
-    1. Zenodo (public record, no authentication)
-    2. Figshare API v2 (works anonymously; a token is used only if one is set)
+    1. Zenodo (public record, no auth)
+    2. Figshare API v2 (works anonymously; token used only if one is set)
     3. Figshare direct download (usually blocked by AWS WAF; last resort)
 
-    The download is written to a temporary sibling file and validated before being
-    moved into place, so a failed or challenged transfer never leaves a partial
-    file that later looks like a populated cache.
+    Download written to a temporary sibling file and validated before being
+    stored. Prevents a failed or challenged transfer leaving a file that
+    populates the cache erroneously.
     """
 
     def __init__(
@@ -145,9 +146,9 @@ class FigshareDownloader:
         """
         Args:
             chunk_size: Download chunk size in bytes (default: 8 MB)
-            api_token: Figshare API token. Optional - the API endpoint serves these
-                files anonymously. Can also be set via the FIGSHARE_API_TOKEN
-                environment variable.
+            api_token: Figshare API token. Optional - the API endpoint serves
+                these files anonymously. Can also be set via the
+                FIGSHARE_API_TOKEN environment variable.
         """
         self.chunk_size = chunk_size
         self.api_token = api_token or os.getenv("FIGSHARE_API_TOKEN")
@@ -206,10 +207,10 @@ class FigshareDownloader:
     def _try_figshare_api(self, write_path: str) -> bool:
         """Try the Figshare API v2 endpoint. Returns True if bytes were written.
 
-        This endpoint serves the files anonymously, so no token is required. When a
-        token happens to be configured we send it, but its absence is not a reason
-        to skip the attempt - that gate was why anonymous users could not download
-        anything while the WAF was blocking the direct host.
+        This endpoint serves the files anonymously; no token required. Token
+        sent if configured. Absence does not prevent the attempt. That gate
+        prevents anonymous users from downloading anything while the WAF was
+        blocking the direct host.
         """
         try:
             logger.info("Attempting Figshare API v2 download...")
@@ -241,8 +242,8 @@ class FigshareDownloader:
     def _try_figshare_direct(self, write_path: str) -> bool:
         """Try the direct Figshare host. Returns True if bytes were written.
 
-        This host sits behind an AWS WAF that answers our requests with an HTTP 202
-        challenge and no body, so this is a last-resort fallback.
+        This host sits behind an AWS WAF that answers our requests with an
+        HTTP 202 challenge and no body, so this is a last-resort fallback.
         """
         try:
             logger.info("Attempting direct Figshare download...")

--- a/src/scdiffeq/datasets/_human_hematopoiesis.py
+++ b/src/scdiffeq/datasets/_human_hematopoiesis.py
@@ -222,7 +222,7 @@ class HumanHematopoiesisDataset(ABCParse.ABCParse):
         return self._adata
 
 
-# -- download function for unprocessed data: -----------------------------------
+# -- download function for unprocessed data: ----------------------------------
 def _download_unprocessed_human_hematopoiesis(
     data_dir=os.getcwd(),
     skip_scaling: bool = False,

--- a/src/scdiffeq/datasets/_human_hematopoiesis.py
+++ b/src/scdiffeq/datasets/_human_hematopoiesis.py
@@ -129,7 +129,7 @@ class UnProcessedHumanHematpoiesisDataHandler(ABCParse.ABCParse):
         adata = adata.copy()
 
         self.SCALER_MODEL = sklearn.preprocessing.StandardScaler()
-        self.PCA_MODEL = sklearn.decomposition.PCA(n_components=50)
+        self.PCA_MODEL = sklearn.decomposition.PCA(n_components=50, random_state=0)
         self.UMAP_MODEL = umap.UMAP(
             n_components=2,
             n_neighbors=25,

--- a/src/scdiffeq/datasets/_larry_in_vitro.py
+++ b/src/scdiffeq/datasets/_larry_in_vitro.py
@@ -35,9 +35,11 @@ _VARIANTS = {
         "figshare_id": 52612805,
         "stem": "larry_unprocessed",
         "legacy_fnames": ("larry_fate_prediction.h5ad",),
-        # Prebuilt equivalent of running the default preprocessing on this
-        # variant; downloaded instead of recomputed when available.
-        "processed_fname": "larry_unprocessed.processed.h5ad",
+        # A prebuilt "larry_unprocessed.processed.h5ad" exists in the Zenodo
+        # record but is deliberately not registered here. It is 2.93 GB against
+        # 2.16 GB for the raw file, and local preprocessing takes ~30 s, so
+        # fetching it costs roughly 285 s of extra transfer at the measured
+        # ~2.7 MB/s to save ~30 s of compute. Set "processed_fname" to re-enable.
     },
 }
 

--- a/src/scdiffeq/datasets/_larry_in_vitro.py
+++ b/src/scdiffeq/datasets/_larry_in_vitro.py
@@ -1,6 +1,8 @@
 # -- import packages: ----------------------------------------------------------
 import ABCParse
 import anndata
+import dataclasses
+import h5py
 import logging
 import numpy as np
 import os
@@ -8,6 +10,7 @@ import pandas as pd
 import pathlib
 import sklearn.decomposition
 import sklearn.preprocessing
+import warnings
 
 
 # -- import local dependencies: ------------------------------------------------
@@ -15,51 +18,276 @@ from .. import io
 from ._figshare_downloader import figshare_downloader
 
 # -- set type hints: -----------------------------------------------------------
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Tuple, Union
 
 # -- configure logger: ----------------------------------------------------------
 logger = logging.getLogger(__name__)
 
 
-def _annotate_larry_cytotrace(adata: anndata.AnnData, data_dir: Union[str, pathlib.Path]) -> Dict[str, pd.DataFrame]:
-    
-    """ """
-    
-    obs_write_path = str(pathlib.Path(data_dir).joinpath("larry.ct_obs_df.csv"))
-    var_write_path = str(pathlib.Path(data_dir).joinpath("larry.ct_var_df.csv"))    
-    
-    figshare_downloader(
-        figshare_id="54312011",
-        write_path=obs_write_path,
-    )
-    figshare_downloader(
-        figshare_id="54312008",
-        write_path=var_write_path,
-    )
-    
-    obs_df = pd.read_csv(obs_write_path, index_col = 0)
-    var_df = pd.read_csv(var_write_path, index_col = 0)
+# -- variant registry: ---------------------------------------------------------
+_VARIANTS = {
+    None: {
+        "figshare_id": 55415231,
+        "stem": "larry",
+        "legacy_fnames": ("larry.h5ad",),
+    },
+    "gene_filtered": {
+        "figshare_id": 52612805,
+        "stem": "larry_gene_filtered",
+        "legacy_fnames": ("larry_fate_prediction.h5ad", "larry_gene_filtered.h5ad"),
+    },
+}
 
-    # Convert indices to strings
-    obs_df.index = obs_df.index.astype(str)
-    var_df.index = var_df.index.astype(str)
-    
-    # Convert all columns to strings
-    for col in obs_df.columns:
-        obs_df[col] = obs_df[col].astype(str)
-    for col in var_df.columns:
-        var_df[col] = var_df[col].astype(str)
+# ``fate_prediction`` was a misleading name: it resolves to
+# ``adata.Weinreb2020.in_vitro.gene_filtered.h5ad``, the recipe's gene-filtered
+# intermediate, while the *default* variant is the object that ships a precomputed
+# ``X_pca``. The names pointed the wrong way round.
+_VARIANT_ALIASES = {"fate_prediction": "gene_filtered"}
 
-    adata.obs = pd.concat([adata.obs, obs_df], axis = 1)
-    adata.var = pd.concat([adata.var, var_df], axis = 1)
 
+def _resolve_variant(variant: Optional[str]) -> Optional[str]:
+    """Canonicalize ``variant``, warning once on a deprecated alias.
+
+    Idempotent: re-resolving an already-canonical name never re-warns, which lets
+    both ``larry()`` and ``LARRYInVitroDataset.__init__`` call it without emitting
+    the warning twice.
+    """
+    if variant in _VARIANT_ALIASES:
+        canonical = _VARIANT_ALIASES[variant]
+        message = (
+            f"variant={variant!r} is deprecated and will be removed in a future "
+            f"release; use variant={canonical!r} instead. Note that this variant is "
+            f"the gene-filtered intermediate and does not ship a precomputed X_pca."
+        )
+        warnings.warn(message, DeprecationWarning, stacklevel=3)
+        # DeprecationWarning is hidden by default outside __main__, so also log it.
+        logger.warning(message)
+        return canonical
+
+    if variant not in _VARIANTS:
+        valid = sorted(
+            repr(key) for key in list(_VARIANTS) + list(_VARIANT_ALIASES)
+        )
+        raise ValueError(
+            f"Unknown variant: {variant!r}. Valid options: {', '.join(valid)}."
+        )
+    return variant
+
+
+# -- lightweight, read-only h5ad introspection: --------------------------------
+@dataclasses.dataclass(frozen=True)
+class _H5ADProbe:
+    """Metadata-only summary of an ``.h5ad`` file.
+
+    Reads HDF5 metadata for a handful of nodes -- a few KB regardless of whether
+    the file is 80 MB or 5.3 GB. This is what makes it viable to ask "is this
+    cached file raw or already processed?" without loading it.
+    """
+
+    path: pathlib.Path
+    readable: bool = False
+    n_obs: Optional[int] = None
+    n_vars: Optional[int] = None
+    obsm_keys: Tuple[str, ...] = ()
+    obs_columns: Tuple[str, ...] = ()
+    pca_dim: Optional[int] = None
+    error: Optional[str] = None
+
+
+def _decode(value) -> str:
+    return value.decode() if isinstance(value, bytes) else str(value)
+
+
+def _frame_shape_and_columns(node) -> Tuple[Optional[int], Tuple[str, ...]]:
+    """Length and column names of an h5ad-encoded DataFrame, reading no column data."""
+    if isinstance(node, h5py.Dataset):  # legacy structured-array layout
+        return int(node.shape[0]), tuple(node.dtype.names or ())
+
+    index_key = _decode(node.attrs.get("_index", "_index"))
+
+    n = None
+    if index_key in node:
+        index_node = node[index_key]
+        if isinstance(index_node, h5py.Dataset):
+            n = int(index_node.shape[0])
+        elif "codes" in index_node:  # categorical index
+            n = int(index_node["codes"].shape[0])
+
+    columns = node.attrs.get("column-order")
+    if columns is None:
+        columns = [key for key in node.keys() if key != index_key]
+
+    return n, tuple(_decode(col) for col in columns)
+
+
+def _probe_h5ad(path: Union[str, pathlib.Path]) -> _H5ADProbe:
+    """Open an ``.h5ad`` read-only and report its structure."""
+    path = pathlib.Path(path)
+
+    if (not path.exists()) or path.stat().st_size == 0:
+        return _H5ADProbe(path=path, error="missing or empty")
+
+    try:
+        with h5py.File(path, "r") as f:
+            n_obs, obs_columns = _frame_shape_and_columns(f["obs"])
+            n_vars, _ = _frame_shape_and_columns(f["var"])
+
+            obsm = f.get("obsm")
+            obsm_keys = tuple(obsm.keys()) if obsm is not None else ()
+
+            pca_dim = None
+            if obsm is not None and "X_pca" in obsm:
+                pca_node = obsm["X_pca"]
+                if isinstance(pca_node, h5py.Dataset) and pca_node.ndim == 2:
+                    pca_dim = int(pca_node.shape[1])
+
+            return _H5ADProbe(
+                path=path,
+                readable=True,
+                n_obs=n_obs,
+                n_vars=n_vars,
+                obsm_keys=obsm_keys,
+                obs_columns=obs_columns,
+                pca_dim=pca_dim,
+            )
+    except (OSError, KeyError, ValueError) as e:
+        # truncated download, or a non-HDF5 payload such as a WAF challenge page
+        return _H5ADProbe(path=path, error=f"{type(e).__name__}: {e}")
+
+
+# -- atomic write helpers: -----------------------------------------------------
+def _tmp_sibling(path: pathlib.Path, suffix: str) -> pathlib.Path:
+    """Hidden sibling path in the same directory, so ``os.replace`` stays atomic."""
+    return path.with_name(f".{path.name}.{suffix}")
+
+
+def _write_h5ad_atomic(adata: anndata.AnnData, write_path: pathlib.Path) -> None:
+    """Write to a temp sibling, then move into place.
+
+    Preprocessing can fail partway -- CytoTRACE annotation pulls two CSVs over the
+    network -- and without this a half-written file would be left at the processed
+    path and silently returned by every later call.
+    """
+    tmp = _tmp_sibling(write_path, "tmp.h5ad")
+    try:
+        adata.write_h5ad(tmp)
+        os.replace(tmp, write_path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+# -- CytoTRACE annotation: -----------------------------------------------------
+_CYTOTRACE_FILES = {
+    "obs": (54312011, "larry.ct_obs_df.csv"),
+    "var": (54312008, "larry.ct_var_df.csv"),
+}
+
+# Columns the annotation contributes to ``adata.obs`` (used to validate a cache).
+CYTOTRACE_OBS_COLS = ("ct_pseudotime",)
+
+
+def _coerce_annotation_frame(df: pd.DataFrame) -> pd.DataFrame:
+    """String index, but leave numeric columns numeric.
+
+    The previous implementation cast *every* column to ``str``, which is why
+    ``ct_pseudotime`` had to be cast back to float on read.
+    """
+    df = df.copy()
+    df.index = df.index.astype(str)
+    for col in df.columns:
+        numeric = pd.to_numeric(df[col], errors="coerce")
+        df[col] = numeric if numeric.notna().all() else df[col].astype(str)
+    return df
+
+
+def _download_cytotrace_annotations(
+    data_dir: Union[str, pathlib.Path],
+    force: bool = False,
+) -> Dict[str, pd.DataFrame]:
+    """Fetch (once) and load the precomputed CytoTRACE obs/var annotations."""
+    data_dir = pathlib.Path(data_dir)
+
+    frames = {}
+    for key, (figshare_id, fname) in _CYTOTRACE_FILES.items():
+        path = data_dir.joinpath(fname)
+        if force or (not path.exists()) or path.stat().st_size == 0:
+            logger.info(f"Downloading CytoTRACE {key} annotations -> {path}")
+            figshare_downloader(figshare_id=figshare_id, write_path=path)
+        else:
+            logger.debug(f"Using cached CytoTRACE {key} annotations: {path}")
+        frames[key] = _coerce_annotation_frame(pd.read_csv(path, index_col=0))
+
+    return frames
+
+
+def _merge_annotations(
+    target: pd.DataFrame,
+    annotations: pd.DataFrame,
+    axis_name: str,
+) -> pd.DataFrame:
+    """Index-safe left-join of annotations onto ``obs``/``var``.
+
+    Replaces ``pd.concat(..., axis=1)``, which took the *union* of the two indexes:
+    any annotation key absent from the target silently lengthened the frame (an
+    AnnData assignment error), and re-running duplicated column names, after which
+    ``adata.obs['ct_pseudotime']`` returns a DataFrame rather than a Series.
+
+    Reindexing to the target keeps its length fixed and leaves NaN wherever an
+    annotation is unavailable. The var annotations in particular cover only the
+    gene-filtered subset, so partial coverage is normal and not an error.
+    """
+    target = target.copy()
+    target.index = target.index.astype(str)
+
+    overlap = int(target.index.isin(annotations.index).sum())
+    if overlap == 0:
+        logger.warning(
+            f"No CytoTRACE {axis_name} annotations matched: none of {len(target)} "
+            f"{axis_name} names are present in the annotation table. The columns "
+            f"will be added but left empty."
+        )
+    elif overlap < len(target):
+        logger.info(
+            f"CytoTRACE {axis_name} annotations cover {overlap} of {len(target)} "
+            f"{axis_name}; the remainder will be NaN."
+        )
+
+    # Left join: never changes len(target), never duplicates columns.
+    aligned = annotations.reindex(target.index)
+    for col in aligned.columns:
+        if col in target.columns:
+            logger.debug(f"Overwriting existing {axis_name} column {col!r}.")
+        target[col] = aligned[col].values
+
+    return target
+
+
+def _annotate_larry_cytotrace(
+    adata: anndata.AnnData,
+    data_dir: Union[str, pathlib.Path],
+    force: bool = False,
+) -> anndata.AnnData:
+    """Annotate ``adata`` with precomputed CytoTRACE obs/var values."""
+    frames = _download_cytotrace_annotations(data_dir, force=force)
+    adata.obs = _merge_annotations(adata.obs, frames["obs"], axis_name="obs")
+    adata.var = _merge_annotations(adata.var, frames["var"], axis_name="var")
     return adata
+
 
 # -- Controller class: ---------------------------------------------------------
 class LARRYInVitroDataset(ABCParse.ABCParse):
+    N_PCS = 50
+    PCA_RANDOM_STATE = 0
+
+    VARIANTS = _VARIANTS
+    VARIANT_ALIASES = _VARIANT_ALIASES
+
+    # Retained for backwards compatibility with any external caller.
     FIGSHARE_IDS = {
-        None: 55415231,           # New biology-rich dataset (default)
-        "fate_prediction": 52612805,  # Original fate prediction dataset
+        None: 55415231,
+        "gene_filtered": 52612805,
+        "fate_prediction": 52612805,
     }
 
     def __init__(
@@ -70,107 +298,330 @@ class LARRYInVitroDataset(ABCParse.ABCParse):
         reduce_dimensions: bool = True,
         cytotrace: bool = True,
         force_download: bool = False,
+        force_preprocess: bool = False,
         *args,
         **kwargs,
     ):
-
+        # Normalize before __parse__ so self._variant is always canonical.
+        variant = _resolve_variant(variant)
         self.__parse__(locals())
 
+    # -- directories: ---------------------------------------------------------
     @property
-    def _scdiffeq_parent_data_dir(self):
+    def _scdiffeq_parent_data_dir(self) -> pathlib.Path:
         path = pathlib.Path(self._data_dir).joinpath("scdiffeq_data")
-        if not path.exists():
-            path.mkdir()
+        path.mkdir(parents=True, exist_ok=True)
         return path
 
     @property
-    def data_dir(self):
+    def data_dir(self) -> pathlib.Path:
         path = self._scdiffeq_parent_data_dir.joinpath("larry")
-        if not path.exists():
-            path.mkdir()
+        path.mkdir(parents=True, exist_ok=True)
         return path
 
+    # -- variant spec: --------------------------------------------------------
     @property
-    def FNAME(self):
-        suffix = f"_{self._variant}" if self._variant else ""
-        return f"larry{suffix}.h5ad"
+    def _spec(self) -> Dict:
+        return self.VARIANTS[self._variant]
+
+    @property
+    def _stem(self) -> str:
+        return self._spec["stem"]
+
+    @property
+    def _figshare_id(self) -> int:
+        return self._spec["figshare_id"]
+
+    @property
+    def _DO_PREPROCESSING(self) -> bool:
+        return any([self._filter_genes, self._reduce_dimensions, self._cytotrace])
+
+    @property
+    def _pp_tag(self) -> str:
+        """Filename tag for non-default flag combinations ('' for the default).
+
+        Without this, ``larry(reduce_dimensions=False)`` would write a PCA-less file
+        to the shared processed path and poison the cache for every other caller.
+        """
+        tags = []
+        if not self._filter_genes:
+            tags.append("nofilter")
+        if not self._reduce_dimensions:
+            tags.append("nopca")
+        if not self._cytotrace:
+            tags.append("noct")
+        return f".{'-'.join(tags)}" if tags else ""
+
+    # -- paths: ---------------------------------------------------------------
+    @property
+    def raw_h5ad_path(self) -> pathlib.Path:
+        return self.data_dir.joinpath(f"_{self._stem}.raw.h5ad")
+
+    @property
+    def processed_h5ad_path(self) -> pathlib.Path:
+        return self.data_dir.joinpath(f"{self._stem}.processed{self._pp_tag}.h5ad")
 
     @property
     def h5ad_path(self) -> pathlib.Path:
-        return self.data_dir.joinpath(self.FNAME)
+        """Path the returned object is read from."""
+        if self._DO_PREPROCESSING:
+            return self.processed_h5ad_path
+        return self.raw_h5ad_path
+
+    def _model_path(self, kind: str) -> pathlib.Path:
+        """Path for a fitted scaler/PCA.
+
+        The default variant keeps the bare ``scaler.pkl`` / ``pca.pkl`` names that
+        the published quickstart notebook loads. Other variants are namespaced so
+        they no longer silently overwrite each other's models.
+        """
+        prefix = "" if self._variant is None else f"{self._stem}."
+        return self.data_dir.joinpath(f"{prefix}{kind}{self._pp_tag}.pkl")
+
+    # -- legacy cache migration: ----------------------------------------------
+    def _migrate_legacy_cache(self) -> None:
+        """Adopt a pre-existing ``larry.h5ad`` rather than re-downloading GBs.
+
+        Existing installs hold a single file that may be raw *or* processed
+        depending on how it got there, so classify it from HDF5 metadata instead of
+        assuming. The move is an ``os.replace`` within one directory: instant and
+        atomic even at 5.3 GB.
+        """
+        if getattr(self, "_migrated", False):
+            return
+        self._migrated = True
+
+        for legacy_name in self._spec["legacy_fnames"]:
+            legacy_path = self.data_dir.joinpath(legacy_name)
+
+            if not legacy_path.exists():
+                continue
+            if legacy_path in (self.raw_h5ad_path, self.processed_h5ad_path):
+                continue
+
+            probe = _probe_h5ad(legacy_path)
+            if not probe.readable:
+                logger.warning(
+                    f"Ignoring unreadable legacy cache file {legacy_path} "
+                    f"({probe.error}). Delete it to reclaim disk space."
+                )
+                continue
+
+            # Width is the discriminator, not mere presence: a raw upload may also
+            # carry an X_pca of some other width.
+            looks_processed = probe.pca_dim == self.N_PCS
+
+            if looks_processed and self._pp_tag:
+                logger.warning(
+                    f"Legacy cache {legacy_path.name} appears to be preprocessed with "
+                    f"default settings, but non-default preprocessing was requested; "
+                    f"it cannot be reused. Leaving it in place."
+                )
+                continue
+
+            target = self.processed_h5ad_path if looks_processed else self.raw_h5ad_path
+            kind = "processed" if looks_processed else "raw"
+
+            if target.exists():
+                logger.info(
+                    f"{target.name} already exists; leaving legacy file "
+                    f"{legacy_path.name} in place (safe to delete)."
+                )
+                continue
+
+            logger.info(
+                f"Migrating legacy cache: {legacy_path.name} -> {target.name} "
+                f"(detected as {kind}: n_obs={probe.n_obs}, n_vars={probe.n_vars}, "
+                f"X_pca width={probe.pca_dim})"
+            )
+            os.replace(legacy_path, target)
+
+    # -- validation: ----------------------------------------------------------
+    def _validate_processed(self, path: pathlib.Path) -> Tuple[bool, str]:
+        """Structural check on a cached processed file. Returns ``(is_valid, reason)``."""
+        probe = _probe_h5ad(path)
+        if not probe.readable:
+            return False, f"unreadable ({probe.error})"
+
+        if self._reduce_dimensions:
+            if probe.pca_dim is None:
+                return False, "missing obsm['X_pca']"
+            if probe.pca_dim != self.N_PCS:
+                return False, (
+                    f"obsm['X_pca'] has {probe.pca_dim} components "
+                    f"(expected {self.N_PCS})"
+                )
+
+        if self._cytotrace:
+            missing = set(CYTOTRACE_OBS_COLS) - set(probe.obs_columns)
+            if missing:
+                return False, f"missing CytoTRACE obs columns: {sorted(missing)}"
+
+        # Cross-check against raw only when raw is present, so a valid cache is
+        # never invalidated merely because the raw file is unavailable.
+        raw_probe = _probe_h5ad(self.raw_h5ad_path)
+        if raw_probe.readable and probe.n_obs != raw_probe.n_obs:
+            return False, (
+                f"n_obs mismatch (processed={probe.n_obs}, raw={raw_probe.n_obs})"
+            )
+
+        return True, "ok"
+
+    # -- raw acquisition: -----------------------------------------------------
+    def download(self) -> None:
+        """Download the raw file for this variant if it is not already cached."""
+        if self.raw_h5ad_path.exists() and not self._force_download:
+            return
+
+        logger.info(
+            f"Downloading LARRY (variant={self._variant!r}, "
+            f"figshare_id={self._figshare_id}) -> {self.raw_h5ad_path}"
+        )
+        figshare_downloader(
+            figshare_id=self._figshare_id,
+            write_path=self.raw_h5ad_path,
+        )
+        # One download per instance, so a second property access does not re-fetch.
+        self._force_download = False
 
     @property
-    def _DO_PREPROCESSING(self):
-        return any([self._filter_genes, self._reduce_dimensions])
+    def raw_adata(self) -> anndata.AnnData:
+        if not hasattr(self, "_raw_adata"):
+            self._migrate_legacy_cache()
+            self.download()
+            logger.info(f"Reading raw data from {self.raw_h5ad_path}")
+            self._raw_adata = anndata.read_h5ad(self.raw_h5ad_path)
+        return self._raw_adata
 
-    def download(self):
-        figshare_id = self.FIGSHARE_IDS[self._variant]
-        figshare_downloader(
-            figshare_id=figshare_id,
-            write_path=self.h5ad_path,
+    # -- preprocessing steps: -------------------------------------------------
+    def _gene_filtering(self, adata: anndata.AnnData) -> anndata.AnnData:
+        if "use_genes" not in adata.var.columns:
+            # The gene-filtered variant is already filtered and carries no
+            # use_genes column. Warn rather than raise, so this stays a no-op
+            # instead of breaking the call.
+            logger.warning(
+                f"var['use_genes'] not found in {self.raw_h5ad_path.name}; skipping "
+                f"gene filtering (this variant is likely already gene-filtered)."
+            )
+            return adata
+
+        use_genes = adata.var["use_genes"]
+        if use_genes.dtype != bool:
+            use_genes = (
+                use_genes.astype(str).str.strip().str.lower().isin(["true", "1"])
+            )
+
+        logger.info(f"Filtering genes: {adata.n_vars} -> {int(use_genes.sum())}")
+        return adata[:, use_genes.values].copy()
+
+    def _dimension_reduction(self, adata: anndata.AnnData) -> None:
+        """Scale and run PCA, in place on ``adata.obsm``."""
+        scaler = sklearn.preprocessing.StandardScaler()
+        pca = sklearn.decomposition.PCA(
+            n_components=self.N_PCS,
+            random_state=self.PCA_RANDOM_STATE,
         )
 
-    def _gene_filtering(self, adata: anndata.AnnData) -> anndata.AnnData:
-        return adata[:, adata.var["use_genes"]].copy()
-
-    def _dimension_reduction(self, adata: anndata.AnnData):
-        """Do sample dimension reduction"""
-        # -- instantiate models: ----------------------------------------------
-        scaler = sklearn.preprocessing.StandardScaler()
-        pca = sklearn.decomposition.PCA(n_components=50)
-
-        # -- fit transform data: ----------------------------------------------
+        n_bytes = adata.n_obs * adata.n_vars * 8
+        if n_bytes > 8e9:
+            logger.warning(
+                f"Dense scaling of {adata.n_obs} x {adata.n_vars} needs roughly "
+                f"{n_bytes / 1e9:.1f} GB of RAM, and the same again on disk in "
+                f"obsm['X_scaled']. Consider filter_genes=True."
+            )
 
         X_raw = adata.X
         if not isinstance(X_raw, np.ndarray):
             X_raw = X_raw.toarray()
+
         adata.obsm["X_scaled"] = scaler.fit_transform(X_raw)
         adata.obsm["X_pca"] = pca.fit_transform(adata.obsm["X_scaled"])
 
-        # -- save models: -----------------------------------------------------
-        io.write_pickle(
-            obj=scaler,
-            path=self.data_dir.joinpath("scaler.pkl"),
-        )
-        io.write_pickle(
-            obj=pca,
-            path=self.data_dir.joinpath("pca.pkl"),
-        )
+        io.write_pickle(obj=scaler, path=self._model_path("scaler"))
+        io.write_pickle(obj=pca, path=self._model_path("pca"))
 
     def _preprocess(self, adata: anndata.AnnData) -> anndata.AnnData:
-        if self._DO_PREPROCESSING:
-            logger.info("Preprocessing...")
-            if self._cytotrace:
-                _annotate_larry_cytotrace(adata=adata, data_dir=self.data_dir)
-            if self._filter_genes:
-                adata = self._gene_filtering(adata)
-            if self._reduce_dimensions:
-                self._dimension_reduction(adata)
-            adata.write_h5ad(self.h5ad_path)
-            self._adata = adata
-        
-    
-    def _safe_read(self):
-        logger.info(f"Loading data from {self.h5ad_path}")
+        """Run each requested step, then persist the result.
+
+        Ordering is load-bearing: CytoTRACE first, so its var-level annotations
+        survive gene filtering; PCA last, so the scaler and PCA are fit on the
+        filtered gene space.
+        """
+        logger.info(f"Preprocessing LARRY (variant={self._variant!r})...")
+
+        if self._cytotrace:
+            adata = _annotate_larry_cytotrace(
+                adata=adata,
+                data_dir=self.data_dir,
+                force=self._force_download,
+            )
+        if self._filter_genes:
+            adata = self._gene_filtering(adata)
+        if self._reduce_dimensions:
+            self._dimension_reduction(adata)
+
+        logger.info(f"Writing processed data to {self.processed_h5ad_path}")
+        _write_h5ad_atomic(adata, self.processed_h5ad_path)
+
+        return adata
+
+    def _ensure_processed(self) -> None:
+        """Guarantee that ``self.h5ad_path`` exists and is valid."""
+        self._migrate_legacy_cache()
+
+        if not self._DO_PREPROCESSING:
+            self.download()
+            return
+
+        if self._force_download and self.processed_h5ad_path.exists():
+            logger.info(
+                f"force_download=True: discarding stale "
+                f"{self.processed_h5ad_path.name}"
+            )
+            self.processed_h5ad_path.unlink()
+
+        if self.processed_h5ad_path.exists() and not self._force_preprocess:
+            is_valid, reason = self._validate_processed(self.processed_h5ad_path)
+            if is_valid:
+                return
+            logger.warning(
+                f"Cached {self.processed_h5ad_path.name} failed validation "
+                f"({reason}); regenerating from raw."
+            )
+            self.processed_h5ad_path.unlink()
+
+        adata = self.raw_adata  # downloads only if the raw file is absent
+        self._preprocess(adata=adata)
+
+        # Release the large intermediates before re-reading from disk.
+        del adata
+        if hasattr(self, "_raw_adata"):
+            del self._raw_adata
+
+    def _safe_read(self, path: Optional[pathlib.Path] = None) -> anndata.AnnData:
+        path = self.h5ad_path if path is None else path
+        logger.info(f"Loading data from {path}")
         try:
-            adata = anndata.read_h5ad(self.h5ad_path)
-            if "ct_pseudotime" in adata.obs.columns:
-                adata.obs['ct_pseudotime'] = adata.obs['ct_pseudotime'].astype(float)
-            adata.obs.index.name = "index"
-            self._adata = adata
+            adata = anndata.read_h5ad(path)
         except Exception as e:
-            logger.error(f"Error loading data from {self.h5ad_path}: {e}")
-            raise e
+            logger.error(f"Error loading data from {path}: {e}")
+            raise
+
+        # Defensive: files written before the CytoTRACE dtype fix stored these as str.
+        for col in CYTOTRACE_OBS_COLS:
+            if col in adata.obs.columns:
+                adata.obs[col] = pd.to_numeric(adata.obs[col], errors="coerce")
+
+        adata.obs.index.name = "index"
         return adata
 
     @property
     def adata(self) -> anndata.AnnData:
+        """Preprocessed LARRY in vitro AnnData for the requested variant."""
         if not hasattr(self, "_adata"):
-            if not self.h5ad_path.exists() or self._force_download:
-                self.download()
-                adata = anndata.read_h5ad(self.h5ad_path)
-                self._preprocess(adata=adata)
-            return self._safe_read()
+            self._ensure_processed()
+            self._adata = self._safe_read()
+        return self._adata
 
 
 def larry(
@@ -180,27 +631,44 @@ def larry(
     reduce_dimensions: bool = True,
     cytotrace: bool = True,
     force_download: bool = False,
+    force_preprocess: bool = False,
 ) -> anndata.AnnData:
     """LARRY in vitro dataset
+
+    The raw download and the preprocessed result are cached as separate files, so
+    a dataset obtained by any means (including a manual download) is still
+    preprocessed on first use.
 
     Args:
         data_dir: str, default=os.getcwd()
             Path to the directory where the data will be saved.
         variant: Optional[str], default=None
-            Dataset variant to download. None (default) downloads the full biology-rich
-            dataset. "fate_prediction" downloads the original fate prediction dataset.
+            Dataset variant. ``None`` (default) downloads the full, biology-rich
+            dataset, which ships a precomputed ``X_pca``. ``"gene_filtered"``
+            downloads the smaller gene-filtered intermediate
+            (``adata.Weinreb2020.in_vitro.gene_filtered.h5ad``), which does not,
+            and for which ``X_pca`` is computed locally.
+
+            ``variant="fate_prediction"`` is a deprecated alias for
+            ``"gene_filtered"`` and will be removed in a future release.
         filter_genes: bool, default=True
-            Whether to filter genes.
+            Whether to subset to ``adata.var['use_genes']``. A no-op for variants
+            that are already gene-filtered.
         reduce_dimensions: bool, default=True
-            Whether to reduce dimensions.
+            Whether to scale and run PCA (50 components, ``random_state=0``).
         cytotrace: bool, default=True
-            Whether to annotate LARRY with pre-computed CytoTRACE annotations.
+            Whether to annotate with precomputed CytoTRACE values. Applied
+            independently of the other preprocessing flags.
         force_download: bool, default=False
-            Whether to force download the data.
+            Re-download the raw file and regenerate the processed file.
+        force_preprocess: bool, default=False
+            Regenerate the processed file from the cached raw file without
+            re-downloading it.
 
     Returns:
         anndata.AnnData: Preprocessed AnnData object.
     """
+    variant = _resolve_variant(variant)
     data_handler = LARRYInVitroDataset(
         data_dir=data_dir,
         variant=variant,
@@ -208,5 +676,6 @@ def larry(
         reduce_dimensions=reduce_dimensions,
         cytotrace=cytotrace,
         force_download=force_download,
+        force_preprocess=force_preprocess,
     )
     return data_handler.adata

--- a/src/scdiffeq/datasets/_larry_in_vitro.py
+++ b/src/scdiffeq/datasets/_larry_in_vitro.py
@@ -15,7 +15,7 @@ import warnings
 
 # -- import local dependencies: ------------------------------------------------
 from .. import io
-from ._figshare_downloader import figshare_downloader
+from ._figshare_downloader import figshare_downloader, zenodo_file_downloader
 
 # -- set type hints: -----------------------------------------------------------
 from typing import Dict, Optional, Tuple, Union
@@ -31,18 +31,22 @@ _VARIANTS = {
         "stem": "larry",
         "legacy_fnames": ("larry.h5ad",),
     },
-    "gene_filtered": {
+    "unprocessed": {
         "figshare_id": 52612805,
-        "stem": "larry_gene_filtered",
-        "legacy_fnames": ("larry_fate_prediction.h5ad", "larry_gene_filtered.h5ad"),
+        "stem": "larry_unprocessed",
+        "legacy_fnames": ("larry_fate_prediction.h5ad",),
+        # Prebuilt equivalent of running the default preprocessing on this
+        # variant; downloaded instead of recomputed when available.
+        "processed_fname": "larry_unprocessed.processed.h5ad",
     },
 }
 
-# ``fate_prediction`` was a misleading name: it resolves to
-# ``adata.Weinreb2020.in_vitro.gene_filtered.h5ad``, the recipe's gene-filtered
-# intermediate, while the *default* variant is the object that ships a precomputed
-# ``X_pca``. The names pointed the wrong way round.
-_VARIANT_ALIASES = {"fate_prediction": "gene_filtered"}
+# ``fate_prediction`` was a misleading name. It resolves to
+# ``adata.Weinreb2020.in_vitro.gene_filtered.h5ad``, but despite that filename the
+# object is 130,887 x 25,289 with no ``X_pca`` and a ``use_genes`` column to filter
+# *by* -- it is the unprocessed input. The default variant is the one that is
+# already filtered (2,492 genes) and ships a precomputed ``X_pca``.
+_VARIANT_ALIASES = {"fate_prediction": "unprocessed"}
 
 
 def _resolve_variant(variant: Optional[str]) -> Optional[str]:
@@ -57,7 +61,8 @@ def _resolve_variant(variant: Optional[str]) -> Optional[str]:
         message = (
             f"variant={variant!r} is deprecated and will be removed in a future "
             f"release; use variant={canonical!r} instead. Note that this variant is "
-            f"the gene-filtered intermediate and does not ship a precomputed X_pca."
+            f"the unprocessed input (25,289 genes, no precomputed X_pca), not the "
+            f"gene-filtered object its upstream filename suggests."
         )
         warnings.warn(message, DeprecationWarning, stacklevel=3)
         # DeprecationWarning is hidden by default outside __main__, so also log it.
@@ -593,6 +598,36 @@ class LARRYInVitroDataset(ABCParse.ABCParse):
 
         return adata
 
+    def _try_download_processed(self) -> bool:
+        """Fetch a prebuilt processed artifact instead of recomputing it.
+
+        Only valid when the requested flags match the defaults the artifact was
+        built with -- otherwise the prebuilt object is not what was asked for and
+        preprocessing has to run locally. Returns ``False`` whenever the artifact
+        is unavailable, so this is always an optimization, never a requirement.
+        """
+        processed_fname = self._spec.get("processed_fname")
+        if not processed_fname or self._pp_tag:
+            return False
+
+        logger.info(f"Checking for a prebuilt {processed_fname}...")
+        if not zenodo_file_downloader(
+            filename=processed_fname,
+            write_path=self.processed_h5ad_path,
+        ):
+            return False
+
+        is_valid, reason = self._validate_processed(self.processed_h5ad_path)
+        if not is_valid:
+            logger.warning(
+                f"Prebuilt {processed_fname} failed validation ({reason}); "
+                f"falling back to local preprocessing."
+            )
+            self.processed_h5ad_path.unlink(missing_ok=True)
+            return False
+
+        return True
+
     def _ensure_processed(self) -> None:
         """Guarantee that ``self.h5ad_path`` exists and is valid."""
         self._migrate_legacy_cache()
@@ -617,6 +652,9 @@ class LARRYInVitroDataset(ABCParse.ABCParse):
                 f"({reason}); regenerating from raw."
             )
             self.processed_h5ad_path.unlink()
+
+        if self._try_download_processed():
+            return
 
         adata = self.raw_adata  # downloads only if the raw file is absent
         self._preprocess(adata=adata)
@@ -671,14 +709,21 @@ def larry(
         data_dir: str, default=os.getcwd()
             Path to the directory where the data will be saved.
         variant: Optional[str], default=None
-            Dataset variant. ``None`` (default) downloads the full, biology-rich
-            dataset, which ships a precomputed ``X_pca``. ``"gene_filtered"``
-            downloads the smaller gene-filtered intermediate
-            (``adata.Weinreb2020.in_vitro.gene_filtered.h5ad``), which does not,
-            and for which ``X_pca`` is computed locally.
+            Dataset variant.
+
+            ``None`` (default) is the biology-rich object: 130,887 x 2,492, already
+            gene-filtered, shipping a precomputed ``X_pca``, ``X_umap`` and
+            ``X_scaled``.
+
+            ``"unprocessed"`` is the upstream input: 130,887 x 25,289 with no
+            ``X_pca``, carrying a ``use_genes`` column that preprocessing filters
+            by (down to 2,447 genes). ``X_pca`` is computed locally, or downloaded
+            prebuilt when available.
 
             ``variant="fate_prediction"`` is a deprecated alias for
-            ``"gene_filtered"`` and will be removed in a future release.
+            ``"unprocessed"`` and will be removed in a future release. Despite its
+            upstream filename (``...in_vitro.gene_filtered.h5ad``), that object is
+            the unfiltered one.
         filter_genes: bool, default=True
             Whether to subset to ``adata.var['use_genes']``. A no-op for variants
             that are already gene-filtered.

--- a/src/scdiffeq/datasets/_larry_in_vitro.py
+++ b/src/scdiffeq/datasets/_larry_in_vitro.py
@@ -1,4 +1,4 @@
-# -- import packages: ----------------------------------------------------------
+# -- import packages: ---------------------------------------------------------
 import ABCParse
 import anndata
 import dataclasses
@@ -13,18 +13,18 @@ import sklearn.preprocessing
 import warnings
 
 
-# -- import local dependencies: ------------------------------------------------
+# -- import local dependencies: -----------------------------------------------
 from .. import io
 from ._figshare_downloader import figshare_downloader, zenodo_file_downloader
 
-# -- set type hints: -----------------------------------------------------------
+# -- set type hints: ----------------------------------------------------------
 from typing import Dict, Optional, Tuple, Union
 
-# -- configure logger: ----------------------------------------------------------
+# -- configure logger: --------------------------------------------------------
 logger = logging.getLogger(__name__)
 
 
-# -- variant registry: ---------------------------------------------------------
+# -- variant registry: --------------------------------------------------------
 _VARIANTS = {
     None: {
         "figshare_id": 55415231,
@@ -35,19 +35,14 @@ _VARIANTS = {
         "figshare_id": 52612805,
         "stem": "larry_unprocessed",
         "legacy_fnames": ("larry_fate_prediction.h5ad",),
-        # A prebuilt "larry_unprocessed.processed.h5ad" exists in the Zenodo
-        # record but is deliberately not registered here. It is 2.93 GB against
-        # 2.16 GB for the raw file, and local preprocessing takes ~30 s, so
-        # fetching it costs roughly 285 s of extra transfer at the measured
-        # ~2.7 MB/s to save ~30 s of compute. Set "processed_fname" to re-enable.
+        # Prebuilt "larry_unprocessed.processed.h5ad" exists in Zenodo but
+        # deliberately not registered here. 2.93 GB vs. 2.16 GB for the raw
+        # file. Local preprocessing takes ~30s; fetching it costs ~285s of
+        # extra transfer at ~2.7 MB/s (measured). Set "processed_fname" to
+        # re-enable. 
     },
 }
 
-# ``fate_prediction`` was a misleading name. It resolves to
-# ``adata.Weinreb2020.in_vitro.gene_filtered.h5ad``, but despite that filename the
-# object is 130,887 x 25,289 with no ``X_pca`` and a ``use_genes`` column to filter
-# *by* -- it is the unprocessed input. The default variant is the one that is
-# already filtered (2,492 genes) and ships a precomputed ``X_pca``.
 _VARIANT_ALIASES = {"fate_prediction": "unprocessed"}
 
 
@@ -81,7 +76,7 @@ def _resolve_variant(variant: Optional[str]) -> Optional[str]:
     return variant
 
 
-# -- lightweight, read-only h5ad introspection: --------------------------------
+# -- lightweight, read-only h5ad introspection: -------------------------------
 @dataclasses.dataclass(frozen=True)
 class _H5ADProbe:
     """Metadata-only summary of an ``.h5ad`` file.
@@ -106,7 +101,8 @@ def _decode(value) -> str:
 
 
 def _frame_shape_and_columns(node) -> Tuple[Optional[int], Tuple[str, ...]]:
-    """Length and column names of an h5ad-encoded DataFrame, reading no column data."""
+    """Length and column names of an h5ad-encoded DataFrame, reading no column
+    data."""
     if isinstance(node, h5py.Dataset):  # legacy structured-array layout
         return int(node.shape[0]), tuple(node.dtype.names or ())
 
@@ -158,11 +154,11 @@ def _probe_h5ad(path: Union[str, pathlib.Path]) -> _H5ADProbe:
                 pca_dim=pca_dim,
             )
     except (OSError, KeyError, ValueError) as e:
-        # truncated download, or a non-HDF5 payload such as a WAF challenge page
+        # truncated download, or non-HDF5 payload such as a WAF challenge page
         return _H5ADProbe(path=path, error=f"{type(e).__name__}: {e}")
 
 
-# -- atomic write helpers: -----------------------------------------------------
+# -- atomic write helpers: ----------------------------------------------------
 def _tmp_sibling(path: pathlib.Path, suffix: str) -> pathlib.Path:
     """Hidden sibling path in the same directory, so ``os.replace`` stays atomic."""
     return path.with_name(f".{path.name}.{suffix}")
@@ -184,7 +180,7 @@ def _write_h5ad_atomic(adata: anndata.AnnData, write_path: pathlib.Path) -> None
         raise
 
 
-# -- CytoTRACE annotation: -----------------------------------------------------
+# -- CytoTRACE annotation: ----------------------------------------------------
 _CYTOTRACE_FILES = {
     "obs": (54312011, "larry.ct_obs_df.csv"),
     "var": (54312008, "larry.ct_var_df.csv"),
@@ -310,7 +306,7 @@ def _annotate_larry_cytotrace(
     return adata
 
 
-# -- Controller class: ---------------------------------------------------------
+# -- Controller class: --------------------------------------------------------
 class LARRYInVitroDataset(ABCParse.ABCParse):
     N_PCS = 50
     PCA_RANDOM_STATE = 0
@@ -375,8 +371,9 @@ class LARRYInVitroDataset(ABCParse.ABCParse):
     def _pp_tag(self) -> str:
         """Filename tag for non-default flag combinations ('' for the default).
 
-        Without this, ``larry(reduce_dimensions=False)`` would write a PCA-less file
-        to the shared processed path and poison the cache for every other caller.
+        Without this, ``larry(reduce_dimensions=False)`` would write a PCA-less
+        file to the shared processed path and poison the cache for every other
+        caller.
         """
         tags = []
         if not self._filter_genes:
@@ -406,9 +403,9 @@ class LARRYInVitroDataset(ABCParse.ABCParse):
     def _model_path(self, kind: str) -> pathlib.Path:
         """Path for a fitted scaler/PCA.
 
-        The default variant keeps the bare ``scaler.pkl`` / ``pca.pkl`` names that
-        the published quickstart notebook loads. Other variants are namespaced so
-        they no longer silently overwrite each other's models.
+        Default variant keeps the bare ``scaler.pkl`` / ``pca.pkl`` names
+        that the published quickstart notebook loads. Other variants are
+        namespaced so they no longer silently overwrite each other's models.
         """
         prefix = "" if self._variant is None else f"{self._stem}."
         return self.data_dir.joinpath(f"{prefix}{kind}{self._pp_tag}.pkl")
@@ -418,9 +415,9 @@ class LARRYInVitroDataset(ABCParse.ABCParse):
         """Adopt a pre-existing ``larry.h5ad`` rather than re-downloading GBs.
 
         Existing installs hold a single file that may be raw *or* processed
-        depending on how it got there, so classify it from HDF5 metadata instead of
-        assuming. The move is an ``os.replace`` within one directory: instant and
-        atomic even at 5.3 GB.
+        depending on how it got there. Classified from HDF5 metadata instead of
+        assuming. The move is an ``os.replace`` within one directory: instant
+        and atomic even at 5.3 GB.
         """
         if getattr(self, "_migrated", False):
             return

--- a/src/scdiffeq/datasets/_larry_in_vitro.py
+++ b/src/scdiffeq/datasets/_larry_in_vitro.py
@@ -258,9 +258,37 @@ def _merge_annotations(
     for col in aligned.columns:
         if col in target.columns:
             logger.debug(f"Overwriting existing {axis_name} column {col!r}.")
-        target[col] = aligned[col].values
+        target[col] = _h5ad_safe_column(aligned[col]).values
 
     return target
+
+
+def _h5ad_safe_column(values: pd.Series):
+    """Coerce a reindexed column into something anndata can serialize.
+
+    Partial coverage introduces NaN wherever an annotation was unavailable. A
+    bool column then upcasts to ``object`` holding True/False/NaN, which h5py
+    rejects with "Can't implicitly convert non-string objects to strings" -- the
+    var annotations cover only the gene-filtered subset, so this is the normal
+    case for the unfiltered variant, not an edge case.
+
+    Numeric columns represent gaps as NaN natively and are left alone. Anything
+    else becomes a categorical of strings, which encodes missingness properly.
+    """
+    if pd.api.types.is_bool_dtype(values):
+        return values  # a real bool dtype cannot contain NaN
+
+    if pd.api.types.is_numeric_dtype(values):
+        return values
+
+    present = values.notna()
+    if present.all():
+        # Fully covered object column: plain strings write cleanly.
+        return values.astype(str)
+
+    as_str = pd.Series(np.nan, index=values.index, dtype=object)
+    as_str[present] = values[present].astype(str)
+    return pd.Series(pd.Categorical(as_str), index=values.index)
 
 
 def _annotate_larry_cytotrace(

--- a/src/scdiffeq/datasets/_pancreatic_endocrinogenesis.py
+++ b/src/scdiffeq/datasets/_pancreatic_endocrinogenesis.py
@@ -109,7 +109,7 @@ class UnProcessedPancreaticEndocrinogenesisDataset(ABCParse.ABCParse):
         adata = adata.copy()
 
         self.SCALER_MODEL = sklearn.preprocessing.StandardScaler()
-        self.PCA_MODEL = sklearn.decomposition.PCA(n_components=50)
+        self.PCA_MODEL = sklearn.decomposition.PCA(n_components=50, random_state=0)
         self.UMAP_MODEL = umap.UMAP(
             n_components=2, n_neighbors=30, random_state=0, min_dist=0.5
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,14 +2,24 @@
 
 """Shared fixtures.
 
-The suite is offline by design: the datasets are 2-5 GB each, so every download
-is stubbed. Two autouse guards below enforce that, because ZENODO_RECORD_ID now
-points at a real published record and it is otherwise easy to turn a stubbed test
-into a multi-GB transfer without noticing.
+The suite is offline by design: the datasets are 2-5 GB each, so the loaders are
+exercised against tiny synthetic ``.h5ad`` files and every download is stubbed.
+Two autouse guards enforce that, because ZENODO_RECORD_ID points at a real
+published record and it is otherwise easy to turn a stubbed test into a multi-GB
+transfer without noticing.
 """
 
 # -- import packages: ---------------------------------------------------------
+import anndata
+import numpy as np
+import pandas as pd
 import pytest
+
+
+# Large enough that PCA(n_components=50) is well-defined after gene filtering
+# keeps half the vars, and still small enough to be instant.
+N_OBS = 120
+N_VARS = 120
 
 
 @pytest.fixture(autouse=True)
@@ -45,3 +55,52 @@ def no_network(request, monkeypatch):
 
     monkeypatch.setattr(socket.socket, "connect", _blocked)
     monkeypatch.setattr(socket.socket, "connect_ex", _blocked)
+
+
+@pytest.fixture
+def make_adata():
+    """Factory for a small AnnData resembling the raw LARRY layout."""
+
+    def _make(n_obs: int = N_OBS, n_vars: int = N_VARS, with_pca: int = 0, seed: int = 0):
+        rng = np.random.default_rng(seed)
+        X = rng.normal(size=(n_obs, n_vars)).astype(np.float32)
+
+        obs = pd.DataFrame(index=[str(i) for i in range(n_obs)])
+        var = pd.DataFrame(
+            # Half the genes pass the filter, so filtering is observable.
+            {"use_genes": [i % 2 == 0 for i in range(n_vars)]},
+            index=[f"gene_{i}" for i in range(n_vars)],
+        )
+
+        adata = anndata.AnnData(X=X, obs=obs, var=var)
+        if with_pca:
+            adata.obsm["X_pca"] = rng.normal(size=(n_obs, with_pca))
+        return adata
+
+    return _make
+
+
+@pytest.fixture
+def cytotrace_csvs(tmp_path):
+    """Write the two CytoTRACE annotation CSVs the loader would otherwise download.
+
+    Their presence on disk means the loader's ``.exists()`` guard short-circuits
+    the download, which keeps these tests offline.
+    """
+
+    def _write(data_dir, n_obs: int = N_OBS, n_vars: int = N_VARS):
+        data_dir.mkdir(parents=True, exist_ok=True)
+
+        obs_df = pd.DataFrame(
+            {"ct_pseudotime": np.linspace(0, 1, n_obs)},
+            index=[str(i) for i in range(n_obs)],
+        )
+        obs_df.to_csv(data_dir / "larry.ct_obs_df.csv")
+
+        var_df = pd.DataFrame(
+            {"ct_gene_corr": np.linspace(-1, 1, n_vars)},
+            index=[f"gene_{i}" for i in range(n_vars)],
+        )
+        var_df.to_csv(data_dir / "larry.ct_var_df.csv")
+
+    return _write

--- a/tests/test_larry_loader.py
+++ b/tests/test_larry_loader.py
@@ -378,15 +378,42 @@ def test_repeated_merge_does_not_duplicate_columns():
 
 
 # -- prebuilt processed artifact ----------------------------------------------
-def test_prebuilt_artifact_is_skipped_when_unavailable(tmp_path, make_adata, cytotrace_csvs):
-    """With no Zenodo record configured, preprocessing must still run locally."""
+def test_no_variant_registers_a_prebuilt_artifact(tmp_path, make_adata, cytotrace_csvs):
+    """Currently none should: the prebuilt file costs more to fetch than to build.
+
+    2.93 GB prebuilt vs 2.16 GB raw + ~30 s of local preprocessing, at ~2.7 MB/s.
+    """
+
+    for variant in (None, "unprocessed"):
+        handler = LARRYInVitroDataset(data_dir=str(tmp_path), variant=variant)
+        assert handler._spec.get("processed_fname") is None
+        assert handler._try_download_processed() is False
+
+
+def test_prebuilt_artifact_is_used_when_registered(
+    tmp_path, make_adata, cytotrace_csvs, monkeypatch
+):
+    """The mechanism still works, so re-enabling it is a one-line change."""
 
     handler = LARRYInVitroDataset(data_dir=str(tmp_path), variant="unprocessed")
     cytotrace_csvs(handler.data_dir)
-    make_adata().write_h5ad(handler.raw_h5ad_path)
+    monkeypatch.setitem(
+        handler._spec, "processed_fname", "larry_unprocessed.processed.h5ad"
+    )
 
-    assert handler._try_download_processed() is False
-    assert "X_pca" in handler.adata.obsm
+    prebuilt = make_adata(with_pca=LARRYInVitroDataset.N_PCS)
+    prebuilt.obs["ct_pseudotime"] = np.linspace(0, 1, prebuilt.n_obs)
+
+    def _fake_download(filename, write_path, **kwargs):
+        prebuilt.write_h5ad(write_path)
+        return True
+
+    monkeypatch.setattr(
+        "scdiffeq.datasets._larry_in_vitro.zenodo_file_downloader", _fake_download
+    )
+
+    assert handler._try_download_processed() is True
+    assert handler.processed_h5ad_path.exists()
 
 
 def test_prebuilt_artifact_not_used_for_non_default_flags(tmp_path):

--- a/tests/test_larry_loader.py
+++ b/tests/test_larry_loader.py
@@ -154,7 +154,7 @@ def test_reduce_dimensions_false_does_not_loop(planted):
     assert is_valid, reason
 
 
-# -- property semantics -------------------------------------------------------
+# -- property semantics: ------------------------------------------------------
 def test_adata_property_is_stable_across_accesses(planted):
     """The property used to return None on its second access."""
 
@@ -166,7 +166,7 @@ def test_adata_property_is_stable_across_accesses(planted):
     assert second is first
 
 
-# -- determinism (Fix 2) ------------------------------------------------------
+# -- determinism (Fix 2): -----------------------------------------------------
 def test_pca_is_deterministic(tmp_path, make_adata, cytotrace_csvs):
     """Two independent preprocessing runs must produce an identical basis."""
 
@@ -181,7 +181,7 @@ def test_pca_is_deterministic(tmp_path, make_adata, cytotrace_csvs):
     np.testing.assert_array_equal(results[0], results[1])
 
 
-# -- legacy cache migration (Fix 1, migration path) ---------------------------
+# -- legacy cache migration (Fix 1, migration path): --------------------------
 def test_legacy_raw_cache_is_migrated_not_redownloaded(tmp_path, make_adata, cytotrace_csvs):
     """A pre-existing larry.h5ad without X_pca is adopted as the raw input."""
 
@@ -241,7 +241,7 @@ def test_unreadable_legacy_file_is_left_alone(tmp_path, make_adata, cytotrace_cs
     assert not handler.raw_h5ad_path.exists()
 
 
-# -- variant naming (Fix 4) ---------------------------------------------------
+# -- variant naming (Fix 4): --------------------------------------------------
 def test_fate_prediction_alias_warns_and_resolves():
     with pytest.warns(DeprecationWarning, match="unprocessed"):
         assert _resolve_variant("fate_prediction") == "unprocessed"
@@ -285,7 +285,7 @@ def test_deprecated_alias_reaches_the_unprocessed_paths(tmp_path):
     assert "unprocessed" in handler.raw_h5ad_path.name
 
 
-# -- gene-filtered variant without use_genes ----------------------------------
+# -- gene-filtered variant without use_genes: ---------------------------------
 def test_missing_use_genes_is_a_no_op_not_a_crash(tmp_path, make_adata, cytotrace_csvs):
     """The gene-filtered variant ships no use_genes column; that must not raise."""
 
@@ -301,7 +301,7 @@ def test_missing_use_genes_is_a_no_op_not_a_crash(tmp_path, make_adata, cytotrac
     assert result.n_vars == adata.n_vars
 
 
-# -- annotation merge semantics ------------------------------------------------
+# -- annotation merge semantics: ----------------------------------------------
 def test_partial_annotation_coverage_preserves_frame_length():
     """The real var annotations cover only the filtered gene subset."""
 
@@ -377,7 +377,7 @@ def test_repeated_merge_does_not_duplicate_columns():
     assert isinstance(merged["ct_pseudotime"], pd.Series)
 
 
-# -- prebuilt processed artifact ----------------------------------------------
+# -- prebuilt processed artifact: ---------------------------------------------
 def test_no_variant_registers_a_prebuilt_artifact(tmp_path, make_adata, cytotrace_csvs):
     """Currently none should: the prebuilt file costs more to fetch than to build.
 

--- a/tests/test_larry_loader.py
+++ b/tests/test_larry_loader.py
@@ -1,0 +1,353 @@
+# tests/test_larry_loader.py
+
+"""Regression tests for the LARRY loader's caching and preprocessing.
+
+Two defects are covered here, both reported against
+``scdiffeq.datasets.larry(variant="fate_prediction")``:
+
+1. Preprocessing ran only on the download path, so an ``.h5ad`` already on disk --
+   exactly what you get when working around a broken downloader by fetching the
+   file by hand -- was returned raw, with no ``X_pca``.
+2. The raw download and the preprocessed result shared one path, so a preprocess
+   that failed partway left a raw file at the processed path, and every later call
+   silently returned it.
+
+All tests are offline: the raw file is planted on disk and the CytoTRACE CSVs are
+pre-written, so no download is attempted.
+"""
+
+# -- import packages: ---------------------------------------------------------
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# -- import local dependencies: -----------------------------------------------
+from scdiffeq.datasets import larry
+from scdiffeq.datasets._larry_in_vitro import (
+    LARRYInVitroDataset,
+    _merge_annotations,
+    _probe_h5ad,
+    _resolve_variant,
+)
+
+
+@pytest.fixture
+def planted(tmp_path, make_adata, cytotrace_csvs):
+    """Plant a raw .h5ad at the loader's raw path and stage the CytoTRACE CSVs."""
+
+    def _plant(variant=None, **kwargs):
+        handler = LARRYInVitroDataset(data_dir=str(tmp_path), variant=variant, **kwargs)
+        cytotrace_csvs(handler.data_dir)
+        make_adata().write_h5ad(handler.raw_h5ad_path)
+        return handler
+
+    return _plant
+
+
+# -- Defect 1: preprocessing was skipped for files already on disk ------------
+def test_preexisting_raw_file_is_preprocessed(planted, tmp_path):
+    """The reported bug: a cached raw file must still come back with X_pca."""
+
+    planted()
+    adata = larry(data_dir=str(tmp_path))
+
+    assert "X_pca" in adata.obsm, "a pre-existing raw file must still be preprocessed"
+    assert adata.obsm["X_pca"].shape[1] == LARRYInVitroDataset.N_PCS
+    assert "X_scaled" in adata.obsm, "perturbation tools default to use_key='X_scaled'"
+
+
+def test_raw_and_processed_are_separate_files(planted):
+    """Preprocessing must not overwrite the raw download."""
+
+    handler = planted()
+    _ = handler.adata
+
+    assert handler.raw_h5ad_path.exists()
+    assert handler.processed_h5ad_path.exists()
+    assert handler.raw_h5ad_path != handler.processed_h5ad_path
+
+    # The raw file must remain raw, so the processed file can be regenerated.
+    assert _probe_h5ad(handler.raw_h5ad_path).pca_dim is None
+
+
+def test_gene_filtering_is_applied(planted):
+    handler = planted()
+    adata = handler.adata
+
+    raw_n_vars = _probe_h5ad(handler.raw_h5ad_path).n_vars
+    assert adata.n_vars < raw_n_vars
+
+
+def test_cytotrace_runs_without_the_other_flags(planted):
+    """cytotrace=True used to be silently skipped unless another flag was set."""
+
+    handler = planted(filter_genes=False, reduce_dimensions=False, cytotrace=True)
+    adata = handler.adata
+
+    assert "ct_pseudotime" in adata.obs.columns
+    assert adata.obs["ct_pseudotime"].dtype.kind == "f", "must not be cast to str"
+
+
+# -- Defect 2: a bad processed file was returned forever ----------------------
+def test_invalid_processed_file_is_regenerated(planted):
+    """A raw (or truncated) file sitting at the processed path must self-heal."""
+
+    handler = planted()
+    # Simulate a preprocess that died partway and left raw bytes at the target.
+    handler.processed_h5ad_path.write_bytes(handler.raw_h5ad_path.read_bytes())
+
+    is_valid, reason = handler._validate_processed(handler.processed_h5ad_path)
+    assert not is_valid
+    assert "X_pca" in reason
+
+    adata = handler.adata
+    assert "X_pca" in adata.obsm
+
+
+def test_truncated_processed_file_is_regenerated(planted):
+    handler = planted()
+    handler.processed_h5ad_path.write_bytes(b"not an hdf5 file")
+
+    is_valid, reason = handler._validate_processed(handler.processed_h5ad_path)
+    assert not is_valid
+    assert "unreadable" in reason
+
+    assert "X_pca" in handler.adata.obsm
+
+
+def test_valid_processed_cache_is_reused(planted, monkeypatch):
+    """A good cache must not trigger another preprocess."""
+
+    handler = planted()
+    _ = handler.adata
+
+    second = LARRYInVitroDataset(data_dir=handler._data_dir)
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("preprocessing re-ran despite a valid cache")
+
+    monkeypatch.setattr(second, "_preprocess", _boom)
+    assert "X_pca" in second.adata.obsm
+
+
+def test_non_default_flags_get_their_own_cache(planted):
+    """reduce_dimensions=False must not poison the shared processed path."""
+
+    default = planted()
+    nopca = LARRYInVitroDataset(data_dir=default._data_dir, reduce_dimensions=False)
+
+    assert default.processed_h5ad_path != nopca.processed_h5ad_path
+    assert "X_pca" not in nopca.adata.obsm
+    assert "X_pca" in default.adata.obsm
+
+
+def test_reduce_dimensions_false_does_not_loop(planted):
+    """Validity must not demand an X_pca that was never requested."""
+
+    handler = planted(reduce_dimensions=False)
+    _ = handler.adata
+
+    is_valid, reason = handler._validate_processed(handler.processed_h5ad_path)
+    assert is_valid, reason
+
+
+# -- property semantics -------------------------------------------------------
+def test_adata_property_is_stable_across_accesses(planted):
+    """The property used to return None on its second access."""
+
+    handler = planted()
+    first = handler.adata
+    second = handler.adata
+
+    assert second is not None
+    assert second is first
+
+
+# -- determinism (Fix 2) ------------------------------------------------------
+def test_pca_is_deterministic(tmp_path, make_adata, cytotrace_csvs):
+    """Two independent preprocessing runs must produce an identical basis."""
+
+    results = []
+    for i in range(2):
+        data_dir = tmp_path / f"run{i}"
+        handler = LARRYInVitroDataset(data_dir=str(data_dir))
+        cytotrace_csvs(handler.data_dir)
+        make_adata().write_h5ad(handler.raw_h5ad_path)
+        results.append(handler.adata.obsm["X_pca"])
+
+    np.testing.assert_array_equal(results[0], results[1])
+
+
+# -- legacy cache migration (Fix 1, migration path) ---------------------------
+def test_legacy_raw_cache_is_migrated_not_redownloaded(tmp_path, make_adata, cytotrace_csvs):
+    """A pre-existing larry.h5ad without X_pca is adopted as the raw input."""
+
+    handler = LARRYInVitroDataset(data_dir=str(tmp_path))
+    cytotrace_csvs(handler.data_dir)
+    legacy = handler.data_dir / "larry.h5ad"
+    make_adata().write_h5ad(legacy)
+
+    adata = handler.adata
+
+    assert not legacy.exists(), "legacy file should have been renamed"
+    assert handler.raw_h5ad_path.exists()
+    assert "X_pca" in adata.obsm
+
+
+def test_legacy_processed_cache_is_migrated(tmp_path, make_adata, cytotrace_csvs):
+    """A pre-existing file that already has a width-50 X_pca is treated as processed."""
+
+    handler = LARRYInVitroDataset(data_dir=str(tmp_path))
+    cytotrace_csvs(handler.data_dir)
+    legacy = handler.data_dir / "larry.h5ad"
+
+    adata = make_adata(with_pca=LARRYInVitroDataset.N_PCS)
+    adata.obs["ct_pseudotime"] = np.linspace(0, 1, adata.n_obs)
+    adata.write_h5ad(legacy)
+
+    handler._migrate_legacy_cache()
+
+    assert not legacy.exists()
+    assert handler.processed_h5ad_path.exists()
+    assert not handler.raw_h5ad_path.exists(), "must not re-download multi-GB raw data"
+
+
+def test_legacy_file_with_wrong_pca_width_is_treated_as_raw(tmp_path, make_adata, cytotrace_csvs):
+    """Presence of X_pca alone is not enough - the width is the discriminator."""
+
+    handler = LARRYInVitroDataset(data_dir=str(tmp_path))
+    cytotrace_csvs(handler.data_dir)
+    legacy = handler.data_dir / "larry.h5ad"
+    make_adata(with_pca=2).write_h5ad(legacy)
+
+    handler._migrate_legacy_cache()
+
+    assert handler.raw_h5ad_path.exists()
+    assert not handler.processed_h5ad_path.exists()
+
+
+def test_unreadable_legacy_file_is_left_alone(tmp_path, make_adata, cytotrace_csvs):
+    handler = LARRYInVitroDataset(data_dir=str(tmp_path))
+    cytotrace_csvs(handler.data_dir)
+    legacy = handler.data_dir / "larry.h5ad"
+    legacy.write_bytes(b"garbage")
+
+    handler._migrate_legacy_cache()
+
+    assert legacy.exists(), "a file we cannot classify must not be moved"
+    assert not handler.raw_h5ad_path.exists()
+
+
+# -- variant naming (Fix 4) ---------------------------------------------------
+def test_fate_prediction_alias_warns_and_resolves():
+    with pytest.warns(DeprecationWarning, match="gene_filtered"):
+        assert _resolve_variant("fate_prediction") == "gene_filtered"
+
+
+def test_canonical_variants_do_not_warn():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        assert _resolve_variant(None) is None
+        assert _resolve_variant("gene_filtered") == "gene_filtered"
+
+
+def test_unknown_variant_raises_a_useful_error():
+    with pytest.raises(ValueError, match="Unknown variant"):
+        _resolve_variant("nope")
+
+
+def test_variant_paths_do_not_collide(tmp_path):
+    default = LARRYInVitroDataset(data_dir=str(tmp_path), variant=None)
+    filtered = LARRYInVitroDataset(data_dir=str(tmp_path), variant="gene_filtered")
+
+    assert default.raw_h5ad_path != filtered.raw_h5ad_path
+    assert default.processed_h5ad_path != filtered.processed_h5ad_path
+    # Fitted models used to clobber each other across variants.
+    assert default._model_path("pca") != filtered._model_path("pca")
+
+
+def test_default_variant_keeps_documented_pickle_names(tmp_path):
+    """quickstart.ipynb loads scaler.pkl / pca.pkl by these exact names."""
+
+    handler = LARRYInVitroDataset(data_dir=str(tmp_path))
+    assert handler._model_path("scaler").name == "scaler.pkl"
+    assert handler._model_path("pca").name == "pca.pkl"
+
+
+def test_deprecated_alias_reaches_the_gene_filtered_paths(tmp_path):
+    with pytest.warns(DeprecationWarning):
+        handler = LARRYInVitroDataset(data_dir=str(tmp_path), variant="fate_prediction")
+
+    assert handler._variant == "gene_filtered"
+    assert "gene_filtered" in handler.raw_h5ad_path.name
+
+
+# -- gene-filtered variant without use_genes ----------------------------------
+def test_missing_use_genes_is_a_no_op_not_a_crash(tmp_path, make_adata, cytotrace_csvs):
+    """The gene-filtered variant ships no use_genes column; that must not raise."""
+
+    handler = LARRYInVitroDataset(data_dir=str(tmp_path), variant="gene_filtered")
+    cytotrace_csvs(handler.data_dir)
+
+    adata = make_adata()
+    del adata.var["use_genes"]
+    adata.write_h5ad(handler.raw_h5ad_path)
+
+    result = handler.adata
+    assert "X_pca" in result.obsm
+    assert result.n_vars == adata.n_vars
+
+
+# -- annotation merge semantics ------------------------------------------------
+def test_partial_annotation_coverage_preserves_frame_length():
+    """The real var annotations cover only the filtered gene subset."""
+
+    target = pd.DataFrame(index=[str(i) for i in range(10)])
+    annotations = pd.DataFrame(
+        {"ct_gene_corr": [0.1, 0.2, 0.3]}, index=["1", "3", "5"]
+    )
+
+    merged = _merge_annotations(target, annotations, axis_name="var")
+
+    assert len(merged) == 10, "pd.concat used to take the union and change length"
+    assert merged.loc["1", "ct_gene_corr"] == pytest.approx(0.1)
+    assert pd.isna(merged.loc["0", "ct_gene_corr"])
+
+
+def test_annotations_outside_the_target_are_dropped():
+    """Annotation keys absent from the target must not lengthen the frame."""
+
+    target = pd.DataFrame(index=["0", "1"])
+    annotations = pd.DataFrame(
+        {"ct_pseudotime": [0.1, 0.2, 0.3]}, index=["0", "1", "999"]
+    )
+
+    merged = _merge_annotations(target, annotations, axis_name="obs")
+
+    assert list(merged.index) == ["0", "1"]
+
+
+def test_repeated_merge_does_not_duplicate_columns():
+    """Re-running used to produce duplicate names, breaking .astype(float)."""
+
+    target = pd.DataFrame(index=["0", "1"])
+    annotations = pd.DataFrame({"ct_pseudotime": [0.1, 0.2]}, index=["0", "1"])
+
+    merged = _merge_annotations(target, annotations, axis_name="obs")
+    merged = _merge_annotations(merged, annotations, axis_name="obs")
+
+    assert list(merged.columns) == ["ct_pseudotime"]
+    assert isinstance(merged["ct_pseudotime"], pd.Series)
+
+
+# -- opt-in integration -------------------------------------------------------
+@pytest.mark.slow
+def test_larry_gene_filtered_end_to_end(tmp_path):
+    """Downloads ~2.2 GB. Run with `pytest -m slow`."""
+
+    adata = larry(variant="gene_filtered", data_dir=str(tmp_path))
+
+    assert "X_pca" in adata.obsm
+    assert adata.obsm["X_pca"].shape[1] == LARRYInVitroDataset.N_PCS

--- a/tests/test_larry_loader.py
+++ b/tests/test_larry_loader.py
@@ -17,6 +17,7 @@ pre-written, so no download is attempted.
 """
 
 # -- import packages: ---------------------------------------------------------
+import pathlib
 import warnings
 
 import numpy as np
@@ -242,15 +243,15 @@ def test_unreadable_legacy_file_is_left_alone(tmp_path, make_adata, cytotrace_cs
 
 # -- variant naming (Fix 4) ---------------------------------------------------
 def test_fate_prediction_alias_warns_and_resolves():
-    with pytest.warns(DeprecationWarning, match="gene_filtered"):
-        assert _resolve_variant("fate_prediction") == "gene_filtered"
+    with pytest.warns(DeprecationWarning, match="unprocessed"):
+        assert _resolve_variant("fate_prediction") == "unprocessed"
 
 
 def test_canonical_variants_do_not_warn():
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
         assert _resolve_variant(None) is None
-        assert _resolve_variant("gene_filtered") == "gene_filtered"
+        assert _resolve_variant("unprocessed") == "unprocessed"
 
 
 def test_unknown_variant_raises_a_useful_error():
@@ -260,7 +261,7 @@ def test_unknown_variant_raises_a_useful_error():
 
 def test_variant_paths_do_not_collide(tmp_path):
     default = LARRYInVitroDataset(data_dir=str(tmp_path), variant=None)
-    filtered = LARRYInVitroDataset(data_dir=str(tmp_path), variant="gene_filtered")
+    filtered = LARRYInVitroDataset(data_dir=str(tmp_path), variant="unprocessed")
 
     assert default.raw_h5ad_path != filtered.raw_h5ad_path
     assert default.processed_h5ad_path != filtered.processed_h5ad_path
@@ -276,19 +277,19 @@ def test_default_variant_keeps_documented_pickle_names(tmp_path):
     assert handler._model_path("pca").name == "pca.pkl"
 
 
-def test_deprecated_alias_reaches_the_gene_filtered_paths(tmp_path):
+def test_deprecated_alias_reaches_the_unprocessed_paths(tmp_path):
     with pytest.warns(DeprecationWarning):
         handler = LARRYInVitroDataset(data_dir=str(tmp_path), variant="fate_prediction")
 
-    assert handler._variant == "gene_filtered"
-    assert "gene_filtered" in handler.raw_h5ad_path.name
+    assert handler._variant == "unprocessed"
+    assert "unprocessed" in handler.raw_h5ad_path.name
 
 
 # -- gene-filtered variant without use_genes ----------------------------------
 def test_missing_use_genes_is_a_no_op_not_a_crash(tmp_path, make_adata, cytotrace_csvs):
     """The gene-filtered variant ships no use_genes column; that must not raise."""
 
-    handler = LARRYInVitroDataset(data_dir=str(tmp_path), variant="gene_filtered")
+    handler = LARRYInVitroDataset(data_dir=str(tmp_path), variant="unprocessed")
     cytotrace_csvs(handler.data_dir)
 
     adata = make_adata()
@@ -376,12 +377,56 @@ def test_repeated_merge_does_not_duplicate_columns():
     assert isinstance(merged["ct_pseudotime"], pd.Series)
 
 
+# -- prebuilt processed artifact ----------------------------------------------
+def test_prebuilt_artifact_is_skipped_when_unavailable(tmp_path, make_adata, cytotrace_csvs):
+    """With no Zenodo record configured, preprocessing must still run locally."""
+
+    handler = LARRYInVitroDataset(data_dir=str(tmp_path), variant="unprocessed")
+    cytotrace_csvs(handler.data_dir)
+    make_adata().write_h5ad(handler.raw_h5ad_path)
+
+    assert handler._try_download_processed() is False
+    assert "X_pca" in handler.adata.obsm
+
+
+def test_prebuilt_artifact_not_used_for_non_default_flags(tmp_path):
+    """The prebuilt object only matches the defaults it was built with."""
+
+    handler = LARRYInVitroDataset(
+        data_dir=str(tmp_path), variant="unprocessed", reduce_dimensions=False
+    )
+    assert handler._pp_tag  # non-default
+    assert handler._try_download_processed() is False
+
+
+def test_invalid_prebuilt_artifact_falls_back_to_local(
+    tmp_path, make_adata, cytotrace_csvs, monkeypatch
+):
+    """A corrupt prebuilt download must not be returned or left on disk."""
+
+    handler = LARRYInVitroDataset(data_dir=str(tmp_path), variant="unprocessed")
+    cytotrace_csvs(handler.data_dir)
+    make_adata().write_h5ad(handler.raw_h5ad_path)
+
+    def _fake_download(filename, write_path, **kwargs):
+        pathlib.Path(write_path).write_bytes(b"not an hdf5 file")
+        return True
+
+    monkeypatch.setattr(
+        "scdiffeq.datasets._larry_in_vitro.zenodo_file_downloader", _fake_download
+    )
+
+    assert handler._try_download_processed() is False
+    assert not handler.processed_h5ad_path.exists(), "bad artifact must be removed"
+    assert "X_pca" in handler.adata.obsm
+
+
 # -- opt-in integration -------------------------------------------------------
 @pytest.mark.slow
-def test_larry_gene_filtered_end_to_end(tmp_path):
+def test_larry_unprocessed_end_to_end(tmp_path):
     """Downloads ~2.2 GB. Run with `pytest -m slow`."""
 
-    adata = larry(variant="gene_filtered", data_dir=str(tmp_path))
+    adata = larry(variant="unprocessed", data_dir=str(tmp_path))
 
     assert "X_pca" in adata.obsm
     assert adata.obsm["X_pca"].shape[1] == LARRYInVitroDataset.N_PCS

--- a/tests/test_larry_loader.py
+++ b/tests/test_larry_loader.py
@@ -329,6 +329,40 @@ def test_annotations_outside_the_target_are_dropped():
     assert list(merged.index) == ["0", "1"]
 
 
+def test_partially_covered_bool_column_stays_writable(tmp_path, make_adata):
+    """A bool annotation with gaps must not become an unwritable object column.
+
+    The real ct_correlates column is bool and covers only 2,492 of the unfiltered
+    variant's 25,289 genes. Reindexing upcasts bool -> object with NaN, which h5py
+    rejects with "Can't implicitly convert non-string objects to strings".
+    """
+
+    adata = make_adata()
+    annotations = pd.DataFrame(
+        {"ct_correlates": [True, False]}, index=list(adata.var_names[:2])
+    )
+
+    adata.var = _merge_annotations(adata.var, annotations, axis_name="var")
+
+    # The real assertion: this must not raise.
+    out = tmp_path / "written.h5ad"
+    adata.write_h5ad(out)
+    assert out.exists()
+
+
+def test_partially_covered_numeric_column_keeps_nan(make_adata):
+    adata = make_adata()
+    annotations = pd.DataFrame(
+        {"ct_gene_corr": [0.5, -0.5]}, index=list(adata.var_names[:2])
+    )
+
+    merged = _merge_annotations(adata.var, annotations, axis_name="var")
+
+    assert merged["ct_gene_corr"].dtype.kind == "f"
+    assert merged["ct_gene_corr"].iloc[0] == pytest.approx(0.5)
+    assert pd.isna(merged["ct_gene_corr"].iloc[-1])
+
+
 def test_repeated_merge_does_not_duplicate_columns():
     """Re-running used to produce duplicate names, breaking .astype(float)."""
 


### PR DESCRIPTION
> Stacked on #112 — base is `feature/zenodo-migration`. Retarget to `main` once that merges.

## Problem

Two defects, both reported against `scdiffeq.datasets.larry(variant="fate_prediction")`:

1. **Preprocessing ran only on the download path.** An `.h5ad` already on disk — exactly what you get after working around the broken downloader by fetching the file by hand — was returned raw, with no `X_pca`. This was the user's second report.
2. **Raw and processed shared one path.** `_preprocess` wrote back to the same file it downloaded, so a preprocess that failed partway left a raw file at the processed path, and every later call silently returned it.

## Changes

- **Split raw/processed paths**, mirroring the pattern `_human_hematopoiesis.py` already uses, and drive preprocessing off the processed file's absence or invalidity rather than off the download.
- **Validate a cached processed file** (X_pca width, CytoTRACE columns, `n_obs` against raw) using h5py metadata only, so checking a 5.3 GB file costs a few KB of reads. Invalid files regenerate instead of being returned forever.
- **Atomic write** for the processed file, so a failed preprocess can no longer leave raw bytes at the processed path.
- **Adopt existing caches** rather than re-downloading GBs: classify a legacy `larry.h5ad` from HDF5 metadata and rename it into the raw or processed slot. Width-50 `X_pca` is the discriminator, since a raw upload may carry an `X_pca` of another width.
- **`adata` property returns the object** — it returned `None` on second access.
- **`cytotrace` runs independently** of `filter_genes`/`reduce_dimensions`, which used to gate it, and no longer re-downloads its two CSVs every call.
- **Left-join the CytoTRACE annotations** instead of `pd.concat(axis=1)`, which took the *union* of indexes: it lengthened the frame when annotation keys were absent, and duplicated columns when re-run.
- **Seed the PCA** (`random_state=0`) here and in the hematopoiesis and pancreas loaders.
- **Rename `variant="fate_prediction"` → `"unprocessed"`**; old name works and warns.

## On the rename

Probing the remote files over HTTP range reads (10 MiB, not 7.5 GB) showed the names pointed the wrong way round:

| variant | shape | `X_pca` |
|---|---|---|
| `None` (default) | 130,887 × 2,492 | present |
| `"fate_prediction"` | 130,887 × 25,289 | **absent** |

Despite its upstream filename (`...in_vitro.gene_filtered.h5ad`), that object is the *unfiltered* input carrying a `use_genes` column to filter by. `"unprocessed"` matches the `download_unprocessed` vocabulary the other two loaders already use.

## On the PCA seed

This gives determinism **going forward**. It does **not** reproduce the published basis, which came from an unseeded randomized SVD and now exists only as a stored array. Please don't describe it as "matches the paper".

## Verification

Run end to end against the real 2.16 GB artifact:
- returns `(130887, 2447)` with `X_pca (130887, 50)`
- `X_pca` **bitwise identical** across independent preprocessing runs
- 0.5 s cache hit on second call; raw file preserved for regeneration
- deprecated alias warns exactly once

51 tests, offline.

## Notes for review

- The end-to-end run is what surfaced the `ct_correlates` fix: it's a **bool** column, and partial annotation coverage (2,492 of 25,289 genes) upcasts it to object with NaN, which h5py refuses to write. This crash was latent in the original code too — the broken download just meant nobody reached it. It only reproduces on this variant; the default has full coverage.
- Fitted models are now variant-namespaced, but the default variant keeps the bare `scaler.pkl`/`pca.pkl` names that `quickstart.ipynb` loads.
- Non-default flag combinations get their own processed filename, so `reduce_dimensions=False` can't poison the shared cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)