### PR TITLE
Document the datasets and cite their sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,85 @@
+# Changelog
+
+## 1.1.1 (unreleased)
+
+### Dataset downloads are working again
+
+The Figshare download host began answering programmatic requests with an HTTP 202
+web-application-firewall challenge and an empty body, which broke every dataset
+download. Downloads are now served from a Zenodo record and verified against its
+published md5 checksums:
+
+**DOI: [10.5281/zenodo.21947161](https://doi.org/10.5281/zenodo.21947161)**
+
+Figshare remains in the cascade as a fallback, via its API endpoint rather than
+the blocked download host. A download that returns a challenge page, a truncated
+body, or anything lacking the expected file signature is now rejected before it
+reaches the cache instead of failing later inside `anndata.read_h5ad`.
+
+### Breaking and behavioural changes
+
+- **`larry(variant="fate_prediction")` is deprecated**; use
+  `variant="unprocessed"`. The old name still works and warns.
+
+  The rename corrects a misleading name. Despite its upstream filename
+  (`adata.Weinreb2020.in_vitro.gene_filtered.h5ad`), that object is the
+  *unfiltered* input: 130,887 × 25,289 with no `X_pca` and a `use_genes` column to
+  filter by. The default variant is the already-filtered one (130,887 × 2,492)
+  that ships a precomputed `X_pca`.
+
+- **Cache layout changed.** The raw download and the preprocessed result are now
+  separate files (`_larry.raw.h5ad` and `larry.processed.h5ad`) rather than
+  sharing one name. Existing caches are detected and renamed into the new layout
+  automatically — multi-gigabyte files are not re-downloaded.
+
+- **PCA is seeded** (`random_state=0`) in the `larry`, `human_hematopoiesis`, and
+  `pancreatic_endocrinogenesis` loaders.
+
+  > **This changes results relative to previous versions.** Dimension reduction
+  > previously used an unseeded randomized SVD, so two runs on identical input
+  > produced different components. Results are now reproducible **going forward**,
+  > but the seeded basis does **not** reproduce the one distributed with the
+  > published analyses, which exists now only as a stored array. If you need that
+  > exact basis, use the `X_pca` shipped inside the dataset rather than
+  > recomputing it.
+
+- **`ipykernel` is no longer a runtime dependency.** It moved to the `dev` extra;
+  a plain install no longer pulls Jupyter machinery. `scikit-learn` and `h5py` are
+  now declared explicitly — both were already imported directly but only satisfied
+  transitively.
+
+### Fixed
+
+- Preprocessing ran only on the download path, so an `.h5ad` already present on
+  disk was returned raw, with no `X_pca`. Preprocessing is now driven by the
+  processed file's absence or invalidity, so a dataset obtained by any route
+  — including a manual download — is preprocessed on first use.
+- The raw download and preprocessed result shared one path, so a preprocess that
+  failed partway left a raw file where the processed one belonged and every later
+  call silently returned it. Writes are now atomic, and a cached processed file is
+  structurally validated (checked from HDF5 metadata, so it costs a few KB even
+  for a 5 GB file) and regenerated if invalid.
+- `LARRYInVitroDataset.adata` returned `None` on its second access.
+- The `cytotrace` flag was ignored unless `filter_genes` or `reduce_dimensions`
+  was also set, and its two annotation CSVs were re-downloaded on every call.
+- CytoTRACE annotations were merged with `pd.concat(axis=1)`, which took the union
+  of the indexes: it lengthened `obs`/`var` when annotation keys were absent from
+  the target, and duplicated columns when run twice. Partially covered annotations
+  are now joined correctly, and a partially covered boolean column no longer
+  produces an object column that cannot be written to `.h5ad`.
+- Fitted `scaler`/`pca` models from different variants overwrote each other. The
+  default variant keeps the documented `scaler.pkl` / `pca.pkl` names; others are
+  namespaced.
+- Non-default preprocessing flags now get their own cache file, so
+  `reduce_dimensions=False` no longer poisons the default cache.
+- `pancreatic_endocrinogenesis` passed a `url_prefix` argument the downloader does
+  not accept, raising `TypeError`.
+
+### Added
+
+- `larry(force_preprocess=True)` regenerates the processed file from the cached
+  raw file without re-downloading it.
+- A test suite (`pytest`, new `test` extra) and a CI workflow that runs it on pull
+  requests. Network-dependent tests are marked `slow` and excluded by default.
+- `scripts/mirror_to_zenodo.py`, the maintainer tool that performs the Zenodo
+  migration.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,13 @@ git clone https://github.com/scDiffEq/scDiffEq.git; cd ./scDiffEq;
 pip install -e .
 ```
 
-### With documentation dependencies
+### Optional dependency groups
+
+| Extra | Contents |
+| --- | --- |
+| `docs` | Sphinx and theme packages for building the documentation |
+| `test` | `pytest`, for running the test suite |
+| `dev` | Jupyter, `ipykernel`, and `pytest` for interactive development |
 
 ```BASH
 # Using uv
@@ -40,6 +46,23 @@ uv sync --extra docs
 # Using pip
 pip install -e ".[docs]"
 ```
+
+## Datasets
+
+```python
+import scdiffeq as sdq
+
+adata = sdq.datasets.larry()
+```
+
+Datasets are downloaded on first use and cached under
+`<data_dir>/scdiffeq_data/`. They are hosted on Zenodo
+([10.5281/zenodo.21947161](https://doi.org/10.5281/zenodo.21947161)); downloads
+need no authentication and are verified against the record's md5 checksums.
+
+The record redistributes data published by other groups — **please cite the
+original publications**, listed on the
+[data page](https://www.scdiffeq.com/data.html) and in the Zenodo record.
 
 ## Main API
   
@@ -65,3 +88,22 @@ model.fit(train_epochs = 1500)
 ## Reproducibility
 
 - All results described in the [manuscript](https://rdcu.be/eVhnL) detailing scDiffEq can be reproduced using notebooks in the companion repository: [scdiffeq-analyses](https://github.com/scDiffEq/scdiffeq-analyses)
+
+## Citation
+
+```bibtex
+@article{vinyard2025scdiffeq,
+  title   = {Learning cell dynamics with neural differential equations},
+  author  = {Vinyard, Michael E. and Rasmussen, Anders W. and Li, Ruitong
+             and Klein, Allon M. and Getz, Gad and Pinello, Luca},
+  journal = {Nature Machine Intelligence},
+  volume  = {7},
+  number  = {12},
+  pages   = {1969--1984},
+  year    = {2025},
+  doi     = {10.1038/s42256-025-01150-3}
+}
+```
+
+If you use the packaged datasets, please also cite their original publications
+(see the [data page](https://www.scdiffeq.com/data.html)).

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,30 +1,10 @@
-numpy<2.0
-scikit-learn>=1.5
-sphinx
-autodoc
-sphinxcontrib-napoleon
-nbsphinx
-tqdm
-lightning>=2.1
-anndata>=0.10.3
-torch>=2.1.0
-pykeops>=2.1.2
-geomloss>=0.2.6
-torchsde>=0.2.6
-ABCParse>=0.0.7
-adata-query>=0.2.1
-cell-neighbors>=0.1.0
-neural-diffeqs>=0.3.2
-torch-nets>=0.1.0
-torch-adata>=0.1
-autodevice>=0.0.2
-cellplots>=0.0.1rc0
-cell-perturb>=0.0.1rc1
-ipython
-sphinx-autodoc-typehints
-pydata-sphinx-theme
-sphinx-copybutton
-sphinx-design
-sphinx-favicon
-myst-parser
--e .
+# Documentation build requirements.
+#
+# Everything is declared in pyproject.toml under [project.optional-dependencies]
+# docs, so this file only points at it. It previously restated the runtime
+# dependency list and drifted out of sync -- pinning torch>=2.1 against a
+# declared >=2.5, ABCParse>=0.0.7 against >=0.1.4, and omitting h5py, scanpy and
+# requests entirely. Add new documentation dependencies to the `docs` extra, not
+# here.
+
+-e ".[docs]"

--- a/docs/source/_api/_datasets/human_hematopoiesis.rst
+++ b/docs/source/_api/_datasets/human_hematopoiesis.rst
@@ -5,16 +5,11 @@
 
 .. title:: human_hematopoiesis
 
-.. toctree::
-   :maxdepth: 2
-   
-   ../../notebooks.quickstart.ipynb
-
 .. autofunction:: scdiffeq.datasets._human_hematopoiesis.human_hematopoiesis
 
 
-    .. button-link:: ../../notebooks/quickstart.ipynb
-        :color: dark
-        :outline:
+.. button-link:: ../../_tutorials/quickstart.html
+    :color: dark
+    :outline:
 
-        More: Quickstart
+    More: Quickstart

--- a/docs/source/_api/datasets.rst
+++ b/docs/source/_api/datasets.rst
@@ -10,7 +10,7 @@ Datasets (``sdq.datasets``)
 
     _datasets/larry
     _datasets/human_hematopoiesis
-    _datasets/pancreas
+    _datasets/pancreatic_endocrinogenesis
 
 .. dropdown:: ``sdq.datasets.larry``
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -154,12 +154,19 @@ Datasets
 
             _api/datasets
 
-         .. button-link:: _api/_datasets/pancreas.rst
+         .. button-link:: _api/_datasets/larry.rst
             :color: primary
             :outline:
             :expand:
 
-            sdq.datasets.pancreas
+            sdq.datasets.larry
+
+         .. button-link:: _api/_datasets/pancreatic_endocrinogenesis.rst
+            :color: primary
+            :outline:
+            :expand:
+
+            sdq.datasets.pancreatic_endocrinogenesis
             
          .. button-link:: _api/_datasets/human_hematopoiesis.rst
             :color: primary

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -1,0 +1,117 @@
+=========================
+Datasets and data sources
+=========================
+
+.. title:: data
+
+The datasets used by ``scdiffeq`` are downloaded on first use and cached locally.
+They are hosted on Zenodo:
+
+    **DOI:** `10.5281/zenodo.21947161 <https://doi.org/10.5281/zenodo.21947161>`_
+
+Downloads require no authentication, and each file is verified against the md5
+checksum published in the record before it is written to the cache.
+
+.. note::
+
+   The datasets were previously served from Figshare. Its download host now sits
+   behind a web application firewall that rejects programmatic requests, so
+   downloads are served from Zenodo instead. Figshare remains a fallback.
+
+
+Citing the data
+===============
+
+The Zenodo record redistributes data published by other groups. **Please cite the
+original publications**, not only the record:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Dataset
+     - Publication
+   * - LARRY *in vitro*
+     - Weinreb C, Rodriguez-Fraticelli A, Camargo FD, Klein AM. Lineage tracing on
+       transcriptional landscapes links state to fate during differentiation.
+       *Science* (2020).
+       `10.1126/science.aaw3381 <https://doi.org/10.1126/science.aaw3381>`_
+   * - Human hematopoiesis
+     - Qiu X, Zhang Y, Martin-Rufino JD, *et al.* Mapping transcriptomic vector
+       fields of single cells. *Cell* (2022).
+       `10.1016/j.cell.2021.12.045 <https://doi.org/10.1016/j.cell.2021.12.045>`_
+   * - Pancreatic endocrinogenesis
+     - Bastidas-Ponce A, Tritschler S, Dony L, *et al.* Comprehensive single cell
+       mRNA profiling reveals a detailed roadmap for pancreatic endocrinogenesis.
+       *Development* (2019).
+       `10.1242/dev.173849 <https://doi.org/10.1242/dev.173849>`_
+
+
+Where files are cached
+======================
+
+Each loader takes a ``data_dir`` argument (default: the current working
+directory) and writes beneath ``<data_dir>/scdiffeq_data/``:
+
+.. code-block:: text
+
+    scdiffeq_data/
+      larry/
+        _larry.raw.h5ad                  # as downloaded
+        larry.processed.h5ad             # after preprocessing
+        scaler.pkl, pca.pkl              # fitted models
+        larry.ct_obs_df.csv              # CytoTRACE annotations
+        larry.ct_var_df.csv
+
+The raw download and the preprocessed result are **separate files**. This means a
+dataset obtained by any route -- including a manual download -- is still
+preprocessed on first use, and a preprocessed file that fails a validity check is
+regenerated from the raw file rather than re-downloaded.
+
+.. note::
+
+   Earlier versions stored both under a single name (``larry.h5ad``). Existing
+   caches are detected and renamed into the new layout automatically; multi-GB
+   files are **not** re-downloaded.
+
+Preprocessing is re-run when the processed file is missing or fails validation.
+To force it explicitly:
+
+.. code-block:: python
+
+    import scdiffeq as sdq
+
+    # regenerate the processed file from the cached raw file (no re-download)
+    adata = sdq.datasets.larry(force_preprocess=True)
+
+    # re-download the raw file as well
+    adata = sdq.datasets.larry(force_download=True)
+
+
+Reproducibility of the PCA
+==========================
+
+Dimension reduction fits a 50-component PCA with ``random_state=0``, so repeated
+runs produce an identical basis.
+
+.. warning::
+
+   This makes results reproducible **going forward**. It does *not* reproduce the
+   basis distributed with the original publications, which was computed with an
+   unseeded randomized SVD and now exists only as a stored array. If you need that
+   exact basis, use the ``X_pca`` shipped inside the dataset rather than
+   recomputing it.
+
+
+Working without network access
+==============================
+
+Files can be fetched by hand from the `Zenodo record
+<https://doi.org/10.5281/zenodo.21947161>`_ and placed in the cache directory
+under the names above. The loaders will pick them up and preprocess them normally.
+
+
+.. toctree::
+   :hidden:
+
+   larry

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,6 +31,7 @@
    _tutorials/quickstart.ipynb
    install
    api
+   data
    tutorials
    analyses
    dependencies

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -51,9 +51,35 @@ If you want to build the documentation locally:
 
     # Using uv
     uv sync --extra docs
-    
+
     # Using pip
     pip install -e ".[docs]"
+
+
+Optional dependency groups
+""""""""""""""""""""""""""
+
+.. list-table::
+   :header-rows: 1
+   :widths: 12 88
+
+   * - Extra
+     - Contents
+   * - ``docs``
+     - Sphinx and theme packages needed to build this documentation.
+   * - ``test``
+     - ``pytest``, for running the test suite.
+   * - ``dev``
+     - Jupyter, ``ipykernel``, and ``pytest`` for interactive development.
+
+.. code-block:: bash
+
+    # run the test suite
+    uv sync --extra test
+    uv run pytest
+
+Network-dependent tests are marked ``slow`` and excluded by default; run them
+with ``pytest -m slow``. Note that they download multi-gigabyte datasets.
 
 
 Troubleshooting

--- a/docs/source/larry.rst
+++ b/docs/source/larry.rst
@@ -1,7 +1,94 @@
-
 =============
 LARRY Dataset
 =============
 
-.. toctree::
-   :hidden:
+.. title:: LARRY
+
+Lineage tracing data from Weinreb *et al.* (`Science
+<https://doi.org/10.1126/science.aaw3381>`_, 2020), in which barcoded
+hematopoietic progenitors are profiled across three timepoints, allowing observed
+clonal fate to be compared against predicted fate.
+
+.. code-block:: python
+
+    import scdiffeq as sdq
+
+    adata = sdq.datasets.larry()
+
+See :doc:`data` for where files are cached and what to cite.
+
+
+Variants
+========
+
+Two variants are available, and the difference between them matters:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 16 14 48
+
+   * - ``variant``
+     - Shape
+     - ``X_pca``
+     - Description
+   * - ``None`` (default)
+     - 130,887 × 2,492
+     - **included**
+     - The biology-rich object. Already gene-filtered, and ships precomputed
+       ``X_pca``, ``X_umap`` and ``X_scaled``.
+   * - ``"unprocessed"``
+     - 130,887 × 25,289
+     - **not included**
+     - The upstream input, before gene filtering. Carries a ``var["use_genes"]``
+       column that preprocessing filters by, reducing it to 2,447 genes. ``X_pca``
+       is computed locally.
+
+.. code-block:: python
+
+    # default: ships its own X_pca
+    adata = sdq.datasets.larry()
+
+    # the unprocessed input; X_pca is computed during preprocessing
+    adata = sdq.datasets.larry(variant="unprocessed")
+
+.. deprecated:: 1.1.1
+   ``variant="fate_prediction"`` is deprecated in favour of
+   ``variant="unprocessed"``. The old name still works and emits a
+   ``DeprecationWarning``.
+
+   The rename corrects a misleading name. That variant's upstream filename is
+   ``adata.Weinreb2020.in_vitro.gene_filtered.h5ad``, but the object it contains is
+   the *unfiltered* one -- the ``gene_filtered`` name refers to the presence of the
+   filtering metadata, not to filtering having been applied. Reading it as
+   "already gene-filtered" led to the reasonable but incorrect expectation that it
+   would carry a precomputed ``X_pca``.
+
+
+Preprocessing
+=============
+
+With default arguments, :func:`~scdiffeq.datasets.larry` annotates the object with
+precomputed CytoTRACE values, filters genes on ``var["use_genes"]``, then scales
+and runs a 50-component PCA:
+
+.. code-block:: python
+
+    adata = sdq.datasets.larry(
+        filter_genes=True,       # subset to var["use_genes"]
+        reduce_dimensions=True,  # StandardScaler + PCA(50, random_state=0)
+        cytotrace=True,          # merge precomputed CytoTRACE annotations
+    )
+
+Each flag is independent; ``cytotrace=True`` is honoured even when the other two
+are disabled. Non-default combinations are cached separately, so
+``reduce_dimensions=False`` does not overwrite the default cache.
+
+The CytoTRACE annotations are keyed to the gene-filtered gene set, so on the
+``"unprocessed"`` variant they cover 2,492 of its 25,289 genes; the remainder are
+``NaN``. This is expected, not an error.
+
+
+API
+===
+
+.. autofunction:: scdiffeq.datasets._larry_in_vitro.larry

--- a/scripts/mirror_to_zenodo.py
+++ b/scripts/mirror_to_zenodo.py
@@ -64,7 +64,10 @@ class ZenodoDeposition:
             "https://sandbox.zenodo.org/api" if sandbox else "https://zenodo.org/api"
         )
         self.session = requests.Session()
-        self.session.params = {"access_token": token}
+        # Send the token as a header, not a query parameter. As a query parameter
+        # it ends up in server logs, proxies, and -- as this script demonstrated --
+        # in the URL echoed by requests' own HTTPError messages.
+        self.session.headers["Authorization"] = f"Bearer {token}"
         self.deposition_id = None
         self.bucket_url = None
 
@@ -84,8 +87,36 @@ class ZenodoDeposition:
         response.raise_for_status()
         return self._adopt(response.json())
 
+    def unlock(self) -> bool:
+        """Reopen a published record for metadata editing.
+
+        A published deposition is locked; PUT returns 404 until it is unlocked
+        with the ``edit`` action. Files stay immutable either way -- only metadata
+        can change. Returns True if the record was published and is now editable.
+        """
+        response = self.session.post(
+            f"{self.base}/deposit/depositions/{self.deposition_id}/actions/edit",
+            timeout=TIMEOUT,
+        )
+        if response.status_code == 201:
+            return True
+        # 400 == already an open draft, which is fine.
+        if response.status_code == 400:
+            return False
+        response.raise_for_status()
+        return False
+
+    def publish(self) -> dict:
+        """Publish the deposition. Required to make edits to a published record live."""
+        response = self.session.post(
+            f"{self.base}/deposit/depositions/{self.deposition_id}/actions/publish",
+            timeout=TIMEOUT,
+        )
+        response.raise_for_status()
+        return response.json()
+
     def update_metadata(self, metadata: dict) -> dict:
-        """Replace the draft's metadata. Editable right up until publication."""
+        """Replace the deposition's metadata."""
         response = self.session.put(
             f"{self.base}/deposit/depositions/{self.deposition_id}",
             json={"metadata": metadata},
@@ -148,11 +179,28 @@ the data at all.</p>
       the fitted scaler/PCA/UMAP models.</li>
 </ul>
 
-<p><strong>Provenance.</strong> These are redistributed and derived copies of
-data published by their original authors; please cite the original publications
-alongside this record. The <code>.h5ad</code> objects carry preprocessing applied
-by scDiffEq (gene filtering, standardization, and a 50-component PCA with a fixed
-random seed).</p>
+<p><strong>Provenance.</strong> These are redistributed and derived copies of data
+published by their original authors. <strong>Please cite the original
+publications</strong> alongside this record:</p>
+<ul>
+  <li><em>LARRY in vitro</em> &mdash; Weinreb C, Rodriguez-Fraticelli A, Camargo
+      FD, Klein AM. Lineage tracing on transcriptional landscapes links state to
+      fate during differentiation. <em>Science</em> (2020).
+      <a href="https://doi.org/10.1126/science.aaw3381">10.1126/science.aaw3381</a></li>
+  <li><em>Human hematopoiesis</em> &mdash; Qiu X, Zhang Y, Martin-Rufino JD, et al.
+      Mapping transcriptomic vector fields of single cells. <em>Cell</em> (2022).
+      <a href="https://doi.org/10.1016/j.cell.2021.12.045">10.1016/j.cell.2021.12.045</a></li>
+  <li><em>Pancreatic endocrinogenesis</em> &mdash; Bastidas-Ponce A, Tritschler S,
+      Dony L, et al. Comprehensive single cell mRNA profiling reveals a detailed
+      roadmap for pancreatic endocrinogenesis. <em>Development</em> (2019).
+      <a href="https://doi.org/10.1242/dev.173849">10.1242/dev.173849</a></li>
+</ul>
+
+<p>The <code>.h5ad</code> objects carry preprocessing applied by scDiffEq (gene
+filtering, standardization, and a 50-component PCA with a fixed random seed).
+Note that the seeded PCA is reproducible going forward but does not reproduce the
+basis distributed with the original publications, which was computed with an
+unseeded randomized SVD.</p>
 """
 
 DEFAULT_METADATA = {
@@ -171,11 +219,45 @@ DEFAULT_METADATA = {
         "neural differential equations",
         "scDiffEq",
     ],
+    # DOIs verified against Crossref (title, journal, year, first author) before
+    # being written here -- these become part of the permanent record.
     "related_identifiers": [
         {
             "identifier": "https://github.com/scDiffEq/scDiffEq",
             "relation": "isSupplementTo",
             "scheme": "url",
+        },
+        # The paper this data supports.
+        {
+            "identifier": "10.1038/s42256-025-01150-3",
+            "relation": "isSupplementTo",
+            "scheme": "doi",
+            "resource_type": "publication-article",
+        },
+        {
+            "identifier": "10.1101/2023.12.06.570508",
+            "relation": "isSupplementTo",
+            "scheme": "doi",
+            "resource_type": "publication-preprint",
+        },
+        # Originating publications for the redistributed datasets.
+        {
+            "identifier": "10.1126/science.aaw3381",  # LARRY in vitro
+            "relation": "isDerivedFrom",
+            "scheme": "doi",
+            "resource_type": "publication-article",
+        },
+        {
+            "identifier": "10.1016/j.cell.2021.12.045",  # human hematopoiesis
+            "relation": "isDerivedFrom",
+            "scheme": "doi",
+            "resource_type": "publication-article",
+        },
+        {
+            "identifier": "10.1242/dev.173849",  # pancreatic endocrinogenesis
+            "relation": "isDerivedFrom",
+            "scheme": "doi",
+            "resource_type": "publication-article",
         },
     ],
 }
@@ -340,8 +422,19 @@ def main() -> int:
                 f"Resuming deposition {deposition.deposition_id} "
                 f"({len(already_uploaded)} file(s) already uploaded)"
             )
+            was_published = deposition.unlock()
+            if was_published:
+                logger.info("Record is published; reopened it for metadata editing")
+
             deposition.update_metadata(metadata)
             logger.info(f"Metadata updated (license: {args.license})")
+
+            if was_published:
+                # An unlocked record stays in edit mode until republished, and its
+                # public metadata does not reflect the change until then. Files are
+                # untouched; this republishes metadata only, keeping the same DOI.
+                deposition.publish()
+                logger.info("Republished (same DOI; files unchanged)")
         else:
             deposition.create(metadata)
             logger.info(


### PR DESCRIPTION
Follow-up to #112 and #113. Two things: crediting the source publications on the Zenodo record, and filling in the documentation gaps those PRs left.

## Zenodo record metadata

The published record now carries related identifiers for the papers the data comes from. **Every DOI was resolved against Crossref** (title, journal, year, first author) before being written, since these become part of a permanent record:

| relation | DOI | |
|---|---|---|
| `isSupplementTo` | `10.1038/s42256-025-01150-3` | scDiffEq, *Nat Mach Intell* 2025 |
| `isSupplementTo` | `10.1101/2023.12.06.570508` | scDiffEq preprint |
| `isDerivedFrom` | `10.1126/science.aaw3381` | LARRY — Weinreb et al., *Science* 2020 |
| `isDerivedFrom` | `10.1016/j.cell.2021.12.045` | hematopoiesis — Qiu et al., *Cell* 2022 |
| `isDerivedFrom` | `10.1242/dev.173849` | pancreas — Bastidas-Ponce et al., *Development* 2019 |

Already applied to the live record: all six present, DOI unchanged, 17 files intact.

Two fixes to `mirror_to_zenodo.py` this required:
- **Send the token as an `Authorization` header, not a query parameter.** As a query parameter it lands in server logs, proxies, and the URL `requests` echoes in `HTTPError` messages — which is exactly how it leaked while making this change.
- **Unlock and republish when editing a published record.** A published deposition is locked and `PUT` returns 404 until the `edit` action reopens it. Republishing keeps the same DOI and leaves files untouched.

## Documentation

The docs had **no prose about datasets at all** — nothing said where data comes from, what to cite, where it is cached, or that the PCA seed changes results. `larry()`'s docstring already covers the API surface through autodoc, so this fills the gaps around it.

- **`docs/source/data.rst`** (new) — Zenodo record and DOI, md5 verification, citations for all three source datasets, cache layout and legacy migration, `force_download` vs `force_preprocess`, working offline.
- **`docs/source/larry.rst`** — was an orphaned stub with an empty toctree. Now a variant comparison table making explicit which variant ships a precomputed `X_pca`, and why the old name misled.
- **`CHANGELOG.md`** (new) — the seeded PCA changes results relative to previous versions and had no home anywhere. Anyone re-running published analyses needs that warning somewhere findable.
- **`install.rst` / `README.md`** — document the `test` and `dev` extras. Following the README and then running `pytest` previously did not work.
- **`README.md`** — Datasets section and a citation block, with author list and page range from Crossref rather than memory.

## Pre-existing breakage fixed

Found while surveying. These fail silently today because `docs.yml` builds with `--keep-going` and no `-W`:

- `_api/datasets.rst` and `api.rst` pointed at `_datasets/pancreas`; the file is `_datasets/pancreatic_endocrinogenesis`
- `larry` had **no button** in the API datasets grid, despite being the flagship dataset
- `_datasets/human_hematopoiesis.rst` referenced a `notebooks/` directory that does not exist (it is `_tutorials/`)
- `docs/requirements.txt` restated the runtime dependency list and had drifted from `pyproject.toml` — `torch>=2.1` against a declared `>=2.5`, `ABCParse>=0.0.7` against `>=0.1.4`, and no `h5py`/`scanpy`/`requests`. Now defers to the `docs` extra.

## Verification

Sphinx build against the real source tree with the package mocked: both new pages build without warnings, and the `pancreas` / `notebooks` references no longer warn. 51 tests pass.

## Known gap, not fixable here

`docs/source/_analyses/quickstart.ipynb:72` shows stale output referencing `scdiffeq_data/larry/larry.h5ad`; the loader now logs `larry.processed.h5ad`. **Editing it here has no effect** — `docs.yml` and `conf.py` both overwrite `_analyses/` and `_tutorials/` from the `scdiffeq-analyses` repo at build time, and the published quickstart is the copy there. That notebook needs the fix upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)